### PR TITLE
fix(ImageIO): Fix loading MetaImage, Nifti, HDF5, MINC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,10 @@
             "dev": true,
             "requires": {
                 "@babel/types": "7.0.0-beta.49",
-                "jsesc": "2.5.1",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "jsesc": "^2.5.1",
+                "lodash": "^4.17.5",
+                "source-map": "^0.5.0",
+                "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "jsesc": {
@@ -75,9 +75,9 @@
             "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.0"
             }
         },
         "@babel/parser": {
@@ -95,7 +95,7 @@
                 "@babel/code-frame": "7.0.0-beta.49",
                 "@babel/parser": "7.0.0-beta.49",
                 "@babel/types": "7.0.0-beta.49",
-                "lodash": "4.17.10"
+                "lodash": "^4.17.5"
             }
         },
         "@babel/traverse": {
@@ -110,10 +110,10 @@
                 "@babel/helper-split-export-declaration": "7.0.0-beta.49",
                 "@babel/parser": "7.0.0-beta.49",
                 "@babel/types": "7.0.0-beta.49",
-                "debug": "3.1.0",
-                "globals": "11.5.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.10"
+                "debug": "^3.1.0",
+                "globals": "^11.1.0",
+                "invariant": "^2.2.0",
+                "lodash": "^4.17.5"
             },
             "dependencies": {
                 "globals": {
@@ -130,9 +130,9 @@
             "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2",
-                "lodash": "4.17.10",
-                "to-fast-properties": "2.0.0"
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.5",
+                "to-fast-properties": "^2.0.0"
             },
             "dependencies": {
                 "to-fast-properties": {
@@ -155,8 +155,8 @@
             "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
             "dev": true,
             "requires": {
-                "call-me-maybe": "1.0.1",
-                "glob-to-regexp": "0.3.0"
+                "call-me-maybe": "^1.0.1",
+                "glob-to-regexp": "^0.3.0"
             }
         },
         "@nodelib/fs.stat": {
@@ -171,14 +171,14 @@
             "integrity": "sha512-IpC/ctwwauiiSrnNTHOG4CyAPz5YwEX8wSSGuTBb0M1mJcAYJCaYZr11dSZTB4K2p2XFY4AY5+SZcW5aub3hSQ==",
             "dev": true,
             "requires": {
-                "before-after-hook": "1.1.0",
-                "btoa-lite": "1.0.0",
-                "debug": "3.1.0",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lodash": "4.17.10",
-                "node-fetch": "2.1.2",
-                "url-template": "2.0.8"
+                "before-after-hook": "^1.1.0",
+                "btoa-lite": "^1.0.0",
+                "debug": "^3.1.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.0",
+                "lodash": "^4.17.4",
+                "node-fetch": "^2.1.1",
+                "url-template": "^2.0.8"
             },
             "dependencies": {
                 "node-fetch": {
@@ -195,11 +195,11 @@
             "integrity": "sha512-4GLFDmp8Up+f4GQGPIzLVd8X9a3yqbZjl761sEdfCH4e5FkEO3I9XRlTEfKSueeCt5OA1lZBb9IHGpZ6Ot0+BQ==",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "3.0.7",
-                "conventional-commits-parser": "2.1.7",
-                "debug": "3.1.0",
-                "import-from": "2.1.0",
-                "lodash": "4.17.10"
+                "conventional-changelog-angular": "^3.0.0",
+                "conventional-commits-parser": "^2.0.0",
+                "debug": "^3.1.0",
+                "import-from": "^2.1.0",
+                "lodash": "^4.17.4"
             }
         },
         "@semantic-release/error": {
@@ -214,20 +214,20 @@
             "integrity": "sha512-oLDvwvOkX+WNG2IXEg2UAGh4hiabJbmz+JsK1Vs+q39A2rLwmDYqmkppA+bUq8xokY6W8xEpdw1EHIhZNqsQ8w==",
             "dev": true,
             "requires": {
-                "@octokit/rest": "15.8.1",
-                "@semantic-release/error": "2.2.0",
-                "aggregate-error": "1.0.0",
-                "bottleneck": "2.3.1",
-                "debug": "3.1.0",
-                "fs-extra": "6.0.1",
-                "globby": "8.0.1",
-                "issue-parser": "2.0.0",
-                "lodash": "4.17.10",
-                "mime": "2.3.1",
-                "p-filter": "1.0.0",
-                "p-retry": "2.0.0",
-                "parse-github-url": "1.0.2",
-                "url-join": "4.0.0"
+                "@octokit/rest": "^15.2.0",
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^1.0.0",
+                "bottleneck": "^2.0.1",
+                "debug": "^3.1.0",
+                "fs-extra": "^6.0.0",
+                "globby": "^8.0.0",
+                "issue-parser": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mime": "^2.0.3",
+                "p-filter": "^1.0.0",
+                "p-retry": "^2.0.0",
+                "parse-github-url": "^1.0.1",
+                "url-join": "^4.0.0"
             },
             "dependencies": {
                 "fs-extra": {
@@ -236,9 +236,9 @@
                     "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "globby": {
@@ -247,13 +247,13 @@
                     "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "dir-glob": "2.0.0",
-                        "fast-glob": "2.2.2",
-                        "glob": "7.1.2",
-                        "ignore": "3.3.8",
-                        "pify": "3.0.0",
-                        "slash": "1.0.0"
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "fast-glob": "^2.0.2",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "jsonfile": {
@@ -262,7 +262,7 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "mime": {
@@ -285,18 +285,18 @@
             "integrity": "sha512-cSTxtCmLRk1SO3spR/4JPXWtnMLP/K79AqaQYhHVVUleRcKdlrxu1A1hO3ADlZ6MVTf1iDPe+lXm4FJ139Neeg==",
             "dev": true,
             "requires": {
-                "@semantic-release/error": "2.2.0",
-                "aggregate-error": "1.0.0",
-                "detect-indent": "5.0.0",
-                "detect-newline": "2.1.0",
-                "execa": "0.10.0",
-                "fs-extra": "6.0.1",
-                "lodash": "4.17.10",
-                "nerf-dart": "1.0.0",
-                "normalize-url": "3.0.1",
-                "parse-json": "4.0.0",
-                "read-pkg": "3.0.0",
-                "registry-auth-token": "3.3.2"
+                "@semantic-release/error": "^2.2.0",
+                "aggregate-error": "^1.0.0",
+                "detect-indent": "^5.0.0",
+                "detect-newline": "^2.1.0",
+                "execa": "^0.10.0",
+                "fs-extra": "^6.0.0",
+                "lodash": "^4.17.4",
+                "nerf-dart": "^1.0.0",
+                "normalize-url": "^3.0.0",
+                "parse-json": "^4.0.0",
+                "read-pkg": "^3.0.0",
+                "registry-auth-token": "^3.3.1"
             },
             "dependencies": {
                 "detect-indent": {
@@ -311,9 +311,9 @@
                     "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "jsonfile": {
@@ -322,7 +322,7 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "load-json-file": {
@@ -331,10 +331,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "normalize-url": {
@@ -349,8 +349,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "read-pkg": {
@@ -359,9 +359,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 }
             }
@@ -372,15 +372,15 @@
             "integrity": "sha512-8eigxfGSy36+mv4rUIbGZAGZkUVZYNXOyRpcG+ZHSeGTqG6hu9uUxmzkfQ2hvK3zSxqrzKPg3MxnhvZL1Qqmrg==",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "3.0.7",
-                "conventional-changelog-writer": "3.0.9",
-                "conventional-commits-parser": "2.1.7",
-                "debug": "3.1.0",
-                "get-stream": "3.0.0",
-                "git-url-parse": "9.0.1",
-                "import-from": "2.1.0",
-                "into-stream": "3.1.0",
-                "lodash": "4.17.10"
+                "conventional-changelog-angular": "^3.0.6",
+                "conventional-changelog-writer": "^3.0.9",
+                "conventional-commits-parser": "^2.1.7",
+                "debug": "^3.1.0",
+                "get-stream": "^3.0.0",
+                "git-url-parse": "^9.0.0",
+                "import-from": "^2.1.0",
+                "into-stream": "^3.1.0",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "git-url-parse": {
@@ -389,8 +389,8 @@
                     "integrity": "sha512-HDXfw3X5PZaPBRFxELatfoYCV4EaYkAGmIApnnAaVPFCJBkpfWTB2/hhQcK0dVX+MsKnkL5uAn30Lfu2KUKLmg==",
                     "dev": true,
                     "requires": {
-                        "git-up": "2.0.10",
-                        "parse-domain": "2.1.1"
+                        "git-up": "^2.0.0",
+                        "parse-domain": "^2.0.0"
                     }
                 }
             }
@@ -407,8 +407,8 @@
             "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
             "dev": true,
             "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
             }
         },
         "accepts": {
@@ -417,7 +417,7 @@
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "2.1.18",
+                "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
             }
         },
@@ -433,7 +433,7 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "dev": true,
             "requires": {
-                "acorn": "5.6.0"
+                "acorn": "^5.0.0"
             }
         },
         "acorn-jsx": {
@@ -442,7 +442,7 @@
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
-                "acorn": "3.3.0"
+                "acorn": "^3.0.4"
             },
             "dependencies": {
                 "acorn": {
@@ -459,7 +459,7 @@
             "integrity": "sha1-j67SxBAIchzxEdodMNmVuFvkK+0=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1"
+                "object-assign": "4.x"
             }
         },
         "agent-base": {
@@ -468,7 +468,7 @@
             "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
             "dev": true,
             "requires": {
-                "es6-promisify": "5.0.0"
+                "es6-promisify": "^5.0.0"
             }
         },
         "aggregate-error": {
@@ -477,8 +477,8 @@
             "integrity": "sha1-iINE2tAiCnLjr1CQYRf0h3GSX6w=",
             "dev": true,
             "requires": {
-                "clean-stack": "1.3.0",
-                "indent-string": "3.2.0"
+                "clean-stack": "^1.0.0",
+                "indent-string": "^3.0.0"
             }
         },
         "ajv": {
@@ -487,10 +487,10 @@
             "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "co": "^4.6.0",
+                "fast-deep-equal": "^1.0.0",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.3.0"
             }
         },
         "ajv-keywords": {
@@ -505,9 +505,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "alphanum-sort": {
@@ -546,7 +546,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "^1.9.0"
             }
         },
         "ansicolors": {
@@ -567,8 +567,8 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -589,16 +589,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -607,7 +607,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -627,13 +627,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -642,7 +642,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -651,7 +651,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -660,7 +660,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -669,7 +669,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -680,7 +680,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -689,7 +689,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -700,9 +700,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -719,14 +719,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -735,7 +735,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -744,7 +744,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -755,10 +755,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -767,7 +767,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -778,7 +778,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -787,7 +787,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -796,9 +796,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -807,7 +807,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -816,7 +816,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -839,19 +839,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -868,7 +868,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "argv-formatter": {
@@ -884,7 +884,7 @@
             "dev": true,
             "requires": {
                 "ast-types-flow": "0.0.7",
-                "commander": "2.13.0"
+                "commander": "^2.11.0"
             }
         },
         "arr-diff": {
@@ -893,7 +893,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -944,8 +944,8 @@
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
             }
         },
         "array-union": {
@@ -954,7 +954,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -986,9 +986,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -1054,12 +1054,22 @@
             "integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
             "dev": true,
             "requires": {
-                "browserslist": "3.2.8",
-                "caniuse-lite": "1.0.30000847",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "6.0.22",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^3.2.0",
+                "caniuse-lite": "^1.0.30000817",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^6.0.20",
+                "postcss-value-parser": "^3.2.3"
+            }
+        },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "^1.2.5",
+                "is-buffer": "^1.1.5"
             }
         },
         "axobject-query": {
@@ -1077,9 +1087,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -1094,11 +1104,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -1115,25 +1125,25 @@
             "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-generator": "6.26.1",
-                "babel-helpers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-register": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "convert-source-map": "1.5.1",
-                "debug": "2.6.9",
-                "json5": "0.5.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "path-is-absolute": "1.0.1",
-                "private": "0.1.8",
-                "slash": "1.0.0",
-                "source-map": "0.5.7"
+                "babel-code-frame": "^6.26.0",
+                "babel-generator": "^6.26.0",
+                "babel-helpers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-register": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "convert-source-map": "^1.5.0",
+                "debug": "^2.6.8",
+                "json5": "^0.5.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.4",
+                "path-is-absolute": "^1.0.1",
+                "private": "^0.1.7",
+                "slash": "^1.0.0",
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "debug": {
@@ -1159,12 +1169,12 @@
             "integrity": "sha512-Qt2lz2egBxNYWqN9JIO2z4NOOf8i4b5JS6CFoYrOZZTDssueiV1jH/jsefyg+86SeNY3rB361/mi3kE1WK2WYQ==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.0.0-beta.49",
-                "@babel/traverse": "7.0.0-beta.49",
-                "@babel/types": "7.0.0-beta.49",
-                "babylon": "7.0.0-beta.47",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0"
+                "@babel/code-frame": "^7.0.0-beta.40",
+                "@babel/traverse": "^7.0.0-beta.40",
+                "@babel/types": "^7.0.0-beta.40",
+                "babylon": "^7.0.0-beta.40",
+                "eslint-scope": "~3.7.1",
+                "eslint-visitor-keys": "^1.0.0"
             },
             "dependencies": {
                 "babylon": {
@@ -1181,14 +1191,14 @@
             "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
             "dev": true,
             "requires": {
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "detect-indent": "4.0.0",
-                "jsesc": "1.3.0",
-                "lodash": "4.17.10",
-                "source-map": "0.5.7",
-                "trim-right": "1.0.1"
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "detect-indent": "^4.0.0",
+                "jsesc": "^1.3.0",
+                "lodash": "^4.17.4",
+                "source-map": "^0.5.7",
+                "trim-right": "^1.0.1"
             },
             "dependencies": {
                 "source-map": {
@@ -1205,9 +1215,9 @@
             "integrity": "sha1-FMGeXxQte0fxmlJDHlKxzLxAozA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-builder-binary-assignment-operator-visitor": {
@@ -1216,9 +1226,9 @@
             "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
             "dev": true,
             "requires": {
-                "babel-helper-explode-assignable-expression": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-explode-assignable-expression": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-builder-react-jsx": {
@@ -1227,9 +1237,9 @@
             "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "esutils": "2.0.2"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "esutils": "^2.0.2"
             }
         },
         "babel-helper-call-delegate": {
@@ -1238,10 +1248,10 @@
             "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-define-map": {
@@ -1250,10 +1260,10 @@
             "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-helper-explode-assignable-expression": {
@@ -1262,9 +1272,9 @@
             "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-explode-class": {
@@ -1273,10 +1283,10 @@
             "integrity": "sha1-fcKjkQ3uAHBW4eMdZAztPVTqqes=",
             "dev": true,
             "requires": {
-                "babel-helper-bindify-decorators": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-bindify-decorators": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-function-name": {
@@ -1285,11 +1295,11 @@
             "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
             "dev": true,
             "requires": {
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-get-function-arity": {
@@ -1298,8 +1308,8 @@
             "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-hoist-variables": {
@@ -1308,8 +1318,8 @@
             "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-optimise-call-expression": {
@@ -1318,8 +1328,8 @@
             "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-regex": {
@@ -1328,9 +1338,9 @@
             "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-helper-remap-async-to-generator": {
@@ -1339,11 +1349,11 @@
             "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helper-replace-supers": {
@@ -1352,12 +1362,12 @@
             "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
             "dev": true,
             "requires": {
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-helpers": {
@@ -1366,8 +1376,8 @@
             "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-loader": {
@@ -1376,9 +1386,9 @@
             "integrity": "sha512-/hbyEvPzBJuGpk9o80R0ZyTej6heEOr59GoEUtn8qFKbnx4cJm9FWES6J/iv644sYgrtVw9JJQkjaLW/bqb5gw==",
             "dev": true,
             "requires": {
-                "find-cache-dir": "1.0.0",
-                "loader-utils": "1.1.0",
-                "mkdirp": "0.5.1"
+                "find-cache-dir": "^1.0.0",
+                "loader-utils": "^1.0.2",
+                "mkdirp": "^0.5.1"
             }
         },
         "babel-messages": {
@@ -1387,7 +1397,7 @@
             "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-check-es2015-constants": {
@@ -1396,7 +1406,7 @@
             "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-syntax-async-functions": {
@@ -1477,9 +1487,9 @@
             "integrity": "sha1-8FiQAUX9PpkHpt3yjaWfIVJYpds=",
             "dev": true,
             "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-generators": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-remap-async-to-generator": "^6.24.1",
+                "babel-plugin-syntax-async-generators": "^6.5.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-async-to-generator": {
@@ -1488,9 +1498,9 @@
             "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
             "dev": true,
             "requires": {
-                "babel-helper-remap-async-to-generator": "6.24.1",
-                "babel-plugin-syntax-async-functions": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-remap-async-to-generator": "^6.24.1",
+                "babel-plugin-syntax-async-functions": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-class-constructor-call": {
@@ -1499,9 +1509,9 @@
             "integrity": "sha1-gNwoVQWsBn3LjWxl4vbxGrd2Xvk=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-class-constructor-call": "6.18.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-syntax-class-constructor-call": "^6.18.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-class-properties": {
@@ -1510,10 +1520,10 @@
             "integrity": "sha1-anl2PqYdM9NvN7YRqp3vgagbRqw=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-plugin-syntax-class-properties": "6.13.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-plugin-syntax-class-properties": "^6.8.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-decorators": {
@@ -1522,11 +1532,11 @@
             "integrity": "sha1-eIAT2PjGtSIr33s0Q5Df13Vp4k0=",
             "dev": true,
             "requires": {
-                "babel-helper-explode-class": "6.24.1",
-                "babel-plugin-syntax-decorators": "6.13.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-explode-class": "^6.24.1",
+                "babel-plugin-syntax-decorators": "^6.13.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -1535,7 +1545,7 @@
             "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -1544,7 +1554,7 @@
             "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -1553,11 +1563,11 @@
             "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -1566,15 +1576,15 @@
             "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
             "dev": true,
             "requires": {
-                "babel-helper-define-map": "6.26.0",
-                "babel-helper-function-name": "6.24.1",
-                "babel-helper-optimise-call-expression": "6.24.1",
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-define-map": "^6.24.1",
+                "babel-helper-function-name": "^6.24.1",
+                "babel-helper-optimise-call-expression": "^6.24.1",
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -1583,8 +1593,8 @@
             "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -1593,7 +1603,7 @@
             "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -1602,8 +1612,8 @@
             "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -1612,7 +1622,7 @@
             "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -1621,9 +1631,9 @@
             "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
             "dev": true,
             "requires": {
-                "babel-helper-function-name": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-function-name": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -1632,7 +1642,7 @@
             "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -1641,9 +1651,9 @@
             "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -1652,10 +1662,10 @@
             "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-strict-mode": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-plugin-transform-strict-mode": "^6.24.1",
+                "babel-runtime": "^6.26.0",
+                "babel-template": "^6.26.0",
+                "babel-types": "^6.26.0"
             }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -1664,9 +1674,9 @@
             "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
             "dev": true,
             "requires": {
-                "babel-helper-hoist-variables": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-helper-hoist-variables": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -1675,9 +1685,9 @@
             "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0"
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -1686,8 +1696,8 @@
             "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
             "dev": true,
             "requires": {
-                "babel-helper-replace-supers": "6.24.1",
-                "babel-runtime": "6.26.0"
+                "babel-helper-replace-supers": "^6.24.1",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -1696,12 +1706,12 @@
             "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
             "dev": true,
             "requires": {
-                "babel-helper-call-delegate": "6.24.1",
-                "babel-helper-get-function-arity": "6.24.1",
-                "babel-runtime": "6.26.0",
-                "babel-template": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-call-delegate": "^6.24.1",
+                "babel-helper-get-function-arity": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-template": "^6.24.1",
+                "babel-traverse": "^6.24.1",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -1710,8 +1720,8 @@
             "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -1720,7 +1730,7 @@
             "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -1729,9 +1739,9 @@
             "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -1740,7 +1750,7 @@
             "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -1749,7 +1759,7 @@
             "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -1758,9 +1768,9 @@
             "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
             "dev": true,
             "requires": {
-                "babel-helper-regex": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "regexpu-core": "2.0.0"
+                "babel-helper-regex": "^6.24.1",
+                "babel-runtime": "^6.22.0",
+                "regexpu-core": "^2.0.0"
             }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -1769,9 +1779,9 @@
             "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
             "dev": true,
             "requires": {
-                "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-                "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
+                "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-export-extensions": {
@@ -1780,8 +1790,8 @@
             "integrity": "sha1-U3OLR+deghhYnuqUbLvTkQm75lM=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-export-extensions": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-plugin-syntax-export-extensions": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-flow-strip-types": {
@@ -1790,8 +1800,8 @@
             "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-flow": "6.18.0",
-                "babel-runtime": "6.26.0"
+                "babel-plugin-syntax-flow": "^6.18.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-object-rest-spread": {
@@ -1800,8 +1810,8 @@
             "integrity": "sha1-DzZpLVD+9rfi1LOsFHgTepY7ewY=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-object-rest-spread": "6.13.0",
-                "babel-runtime": "6.26.0"
+                "babel-plugin-syntax-object-rest-spread": "^6.8.0",
+                "babel-runtime": "^6.26.0"
             }
         },
         "babel-plugin-transform-react-display-name": {
@@ -1810,7 +1820,7 @@
             "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0"
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-react-jsx": {
@@ -1819,9 +1829,9 @@
             "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
             "dev": true,
             "requires": {
-                "babel-helper-builder-react-jsx": "6.26.0",
-                "babel-plugin-syntax-jsx": "6.18.0",
-                "babel-runtime": "6.26.0"
+                "babel-helper-builder-react-jsx": "^6.24.1",
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-react-jsx-self": {
@@ -1830,8 +1840,8 @@
             "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-jsx": "6.18.0",
-                "babel-runtime": "6.26.0"
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-react-jsx-source": {
@@ -1840,8 +1850,8 @@
             "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-jsx": "6.18.0",
-                "babel-runtime": "6.26.0"
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
             }
         },
         "babel-plugin-transform-regenerator": {
@@ -1850,7 +1860,7 @@
             "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
             "dev": true,
             "requires": {
-                "regenerator-transform": "0.10.1"
+                "regenerator-transform": "^0.10.0"
             }
         },
         "babel-plugin-transform-strict-mode": {
@@ -1859,8 +1869,8 @@
             "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0"
+                "babel-runtime": "^6.22.0",
+                "babel-types": "^6.24.1"
             }
         },
         "babel-polyfill": {
@@ -1869,9 +1879,9 @@
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             },
             "dependencies": {
                 "core-js": {
@@ -1894,36 +1904,36 @@
             "integrity": "sha512-W6VIyA6Ch9ePMI7VptNn2wBM6dbG0eSz25HEiL40nQXCsXGTGZSTZu1Iap+cj3Q0S5a7T9+529l/5Bkvd+afNA==",
             "dev": true,
             "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0",
-                "browserslist": "2.11.3",
-                "invariant": "2.2.4",
-                "semver": "5.5.0"
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+                "babel-plugin-transform-async-to-generator": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
+                "babel-plugin-transform-es2015-classes": "^6.23.0",
+                "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-destructuring": "^6.23.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
+                "babel-plugin-transform-es2015-for-of": "^6.23.0",
+                "babel-plugin-transform-es2015-function-name": "^6.22.0",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
+                "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
+                "babel-plugin-transform-es2015-object-super": "^6.22.0",
+                "babel-plugin-transform-es2015-parameters": "^6.23.0",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
+                "babel-plugin-transform-exponentiation-operator": "^6.22.0",
+                "babel-plugin-transform-regenerator": "^6.22.0",
+                "browserslist": "^2.1.2",
+                "invariant": "^2.2.2",
+                "semver": "^5.3.0"
             },
             "dependencies": {
                 "browserslist": {
@@ -1932,8 +1942,8 @@
                     "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "1.0.30000847",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-lite": "^1.0.30000792",
+                        "electron-to-chromium": "^1.3.30"
                     }
                 }
             }
@@ -1944,30 +1954,30 @@
             "integrity": "sha1-1EBQ1rwsn+6nAqrzjXJ6AhBTiTk=",
             "dev": true,
             "requires": {
-                "babel-plugin-check-es2015-constants": "6.22.0",
-                "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-                "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-                "babel-plugin-transform-es2015-classes": "6.24.1",
-                "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-                "babel-plugin-transform-es2015-destructuring": "6.23.0",
-                "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-                "babel-plugin-transform-es2015-for-of": "6.23.0",
-                "babel-plugin-transform-es2015-function-name": "6.24.1",
-                "babel-plugin-transform-es2015-literals": "6.22.0",
-                "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-                "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-                "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-                "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-                "babel-plugin-transform-es2015-object-super": "6.24.1",
-                "babel-plugin-transform-es2015-parameters": "6.24.1",
-                "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-                "babel-plugin-transform-es2015-spread": "6.22.0",
-                "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-                "babel-plugin-transform-es2015-template-literals": "6.22.0",
-                "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-                "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-                "babel-plugin-transform-regenerator": "6.26.0"
+                "babel-plugin-check-es2015-constants": "^6.22.0",
+                "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
+                "babel-plugin-transform-es2015-block-scoping": "^6.24.1",
+                "babel-plugin-transform-es2015-classes": "^6.24.1",
+                "babel-plugin-transform-es2015-computed-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-destructuring": "^6.22.0",
+                "babel-plugin-transform-es2015-duplicate-keys": "^6.24.1",
+                "babel-plugin-transform-es2015-for-of": "^6.22.0",
+                "babel-plugin-transform-es2015-function-name": "^6.24.1",
+                "babel-plugin-transform-es2015-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-systemjs": "^6.24.1",
+                "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
+                "babel-plugin-transform-es2015-object-super": "^6.24.1",
+                "babel-plugin-transform-es2015-parameters": "^6.24.1",
+                "babel-plugin-transform-es2015-shorthand-properties": "^6.24.1",
+                "babel-plugin-transform-es2015-spread": "^6.22.0",
+                "babel-plugin-transform-es2015-sticky-regex": "^6.24.1",
+                "babel-plugin-transform-es2015-template-literals": "^6.22.0",
+                "babel-plugin-transform-es2015-typeof-symbol": "^6.22.0",
+                "babel-plugin-transform-es2015-unicode-regex": "^6.24.1",
+                "babel-plugin-transform-regenerator": "^6.24.1"
             }
         },
         "babel-preset-flow": {
@@ -1976,7 +1986,7 @@
             "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-flow-strip-types": "6.22.0"
+                "babel-plugin-transform-flow-strip-types": "^6.22.0"
             }
         },
         "babel-preset-react": {
@@ -1985,12 +1995,12 @@
             "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-jsx": "6.18.0",
-                "babel-plugin-transform-react-display-name": "6.25.0",
-                "babel-plugin-transform-react-jsx": "6.24.1",
-                "babel-plugin-transform-react-jsx-self": "6.22.0",
-                "babel-plugin-transform-react-jsx-source": "6.22.0",
-                "babel-preset-flow": "6.23.0"
+                "babel-plugin-syntax-jsx": "^6.3.13",
+                "babel-plugin-transform-react-display-name": "^6.23.0",
+                "babel-plugin-transform-react-jsx": "^6.24.1",
+                "babel-plugin-transform-react-jsx-self": "^6.22.0",
+                "babel-plugin-transform-react-jsx-source": "^6.22.0",
+                "babel-preset-flow": "^6.23.0"
             }
         },
         "babel-preset-stage-1": {
@@ -1999,9 +2009,9 @@
             "integrity": "sha1-dpLNfc1oSZB+auSgqFWJz7niv7A=",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-class-constructor-call": "6.24.1",
-                "babel-plugin-transform-export-extensions": "6.22.0",
-                "babel-preset-stage-2": "6.24.1"
+                "babel-plugin-transform-class-constructor-call": "^6.24.1",
+                "babel-plugin-transform-export-extensions": "^6.22.0",
+                "babel-preset-stage-2": "^6.24.1"
             }
         },
         "babel-preset-stage-2": {
@@ -2010,10 +2020,10 @@
             "integrity": "sha1-2eKWD7PXEYfw5k7sYrwHdnIZvcE=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-dynamic-import": "6.18.0",
-                "babel-plugin-transform-class-properties": "6.24.1",
-                "babel-plugin-transform-decorators": "6.24.1",
-                "babel-preset-stage-3": "6.24.1"
+                "babel-plugin-syntax-dynamic-import": "^6.18.0",
+                "babel-plugin-transform-class-properties": "^6.24.1",
+                "babel-plugin-transform-decorators": "^6.24.1",
+                "babel-preset-stage-3": "^6.24.1"
             }
         },
         "babel-preset-stage-3": {
@@ -2022,11 +2032,11 @@
             "integrity": "sha1-g2raCp56f6N8sTj7kyb4eTSkg5U=",
             "dev": true,
             "requires": {
-                "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-                "babel-plugin-transform-async-generator-functions": "6.24.1",
-                "babel-plugin-transform-async-to-generator": "6.24.1",
-                "babel-plugin-transform-exponentiation-operator": "6.24.1",
-                "babel-plugin-transform-object-rest-spread": "6.26.0"
+                "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
+                "babel-plugin-transform-async-generator-functions": "^6.24.1",
+                "babel-plugin-transform-async-to-generator": "^6.24.1",
+                "babel-plugin-transform-exponentiation-operator": "^6.24.1",
+                "babel-plugin-transform-object-rest-spread": "^6.22.0"
             }
         },
         "babel-register": {
@@ -2035,13 +2045,13 @@
             "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
             "dev": true,
             "requires": {
-                "babel-core": "6.26.0",
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.7",
-                "home-or-tmp": "2.0.0",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.4.18"
+                "babel-core": "^6.26.0",
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "home-or-tmp": "^2.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.4.15"
             },
             "dependencies": {
                 "core-js": {
@@ -2058,8 +2068,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             },
             "dependencies": {
                 "core-js": {
@@ -2076,11 +2086,11 @@
             "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-traverse": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "lodash": "4.17.10"
+                "babel-runtime": "^6.26.0",
+                "babel-traverse": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "lodash": "^4.17.4"
             }
         },
         "babel-traverse": {
@@ -2089,15 +2099,15 @@
             "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "babel-messages": "6.23.0",
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "babylon": "6.18.0",
-                "debug": "2.6.9",
-                "globals": "9.18.0",
-                "invariant": "2.2.4",
-                "lodash": "4.17.10"
+                "babel-code-frame": "^6.26.0",
+                "babel-messages": "^6.23.0",
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "babylon": "^6.18.0",
+                "debug": "^2.6.8",
+                "globals": "^9.18.0",
+                "invariant": "^2.2.2",
+                "lodash": "^4.17.4"
             },
             "dependencies": {
                 "debug": {
@@ -2117,10 +2127,10 @@
             "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "esutils": "2.0.2",
-                "lodash": "4.17.10",
-                "to-fast-properties": "1.0.3"
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
             }
         },
         "babylon": {
@@ -2140,13 +2150,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2155,7 +2165,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2164,7 +2174,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -2173,7 +2183,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -2182,9 +2192,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -2230,9 +2240,9 @@
             "integrity": "sha512-SOmOsowQWfXc7ybFARsK3C4MCOWzERaOMV/Fl3Tgjs+5dJWyzo3oa127jL44eMbQiAN17J7SvAs2TRxEScTUmg==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "check-types": "7.3.0",
-                "tryer": "1.0.0"
+                "bluebird": "^3.5.1",
+                "check-types": "^7.3.0",
+                "tryer": "^1.0.0"
             }
         },
         "big.js": {
@@ -2277,15 +2287,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
+                "depd": "~1.1.1",
+                "http-errors": "~1.6.2",
                 "iconv-lite": "0.4.19",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.1",
                 "raw-body": "2.3.2",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.15"
             },
             "dependencies": {
                 "debug": {
@@ -2317,12 +2327,12 @@
             "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
             "dev": true,
             "requires": {
-                "array-flatten": "2.1.1",
-                "deep-equal": "1.0.1",
-                "dns-equal": "1.0.0",
-                "dns-txt": "2.0.2",
-                "multicast-dns": "6.2.3",
-                "multicast-dns-service-types": "1.1.0"
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
             },
             "dependencies": {
                 "array-flatten": {
@@ -2350,7 +2360,7 @@
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2360,9 +2370,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "brorand": {
@@ -2383,12 +2393,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -2397,9 +2407,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.2.0",
-                "browserify-des": "1.0.1",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -2408,9 +2418,9 @@
             "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "browserify-rsa": {
@@ -2419,8 +2429,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -2429,13 +2439,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.1"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -2444,7 +2454,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             }
         },
         "browserslist": {
@@ -2453,8 +2463,8 @@
             "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000847",
-                "electron-to-chromium": "1.3.48"
+                "caniuse-lite": "^1.0.30000844",
+                "electron-to-chromium": "^1.3.47"
             }
         },
         "btoa-lite": {
@@ -2469,9 +2479,9 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.2.1",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
         "buffer-from": {
@@ -2516,19 +2526,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.3",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.3.0",
-                "unique-filename": "1.1.0",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
             }
         },
         "cache-base": {
@@ -2537,15 +2547,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -2583,9 +2593,9 @@
                     "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
                     "dev": true,
                     "requires": {
-                        "prepend-http": "2.0.0",
-                        "query-string": "5.1.1",
-                        "sort-keys": "2.0.0"
+                        "prepend-http": "^2.0.0",
+                        "query-string": "^5.0.1",
+                        "sort-keys": "^2.0.0"
                     }
                 },
                 "prepend-http": {
@@ -2600,9 +2610,9 @@
                     "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
                     "dev": true,
                     "requires": {
-                        "decode-uri-component": "0.2.0",
-                        "object-assign": "4.1.1",
-                        "strict-uri-encode": "1.1.0"
+                        "decode-uri-component": "^0.2.0",
+                        "object-assign": "^4.1.0",
+                        "strict-uri-encode": "^1.0.0"
                     }
                 },
                 "sort-keys": {
@@ -2611,7 +2621,7 @@
                     "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
                     "dev": true,
                     "requires": {
-                        "is-plain-obj": "1.1.0"
+                        "is-plain-obj": "^1.0.0"
                     }
                 }
             }
@@ -2622,7 +2632,7 @@
             "integrity": "sha512-i3xIKd9U4ov0hWXYo08oJy0YVz0krZ9dbTZQim41xkg0IiScptkAK0UilZ5M1WE3gnWjXAa9+cMtrJ5dM+THbA==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.1"
             }
         },
         "call-me-maybe": {
@@ -2637,7 +2647,7 @@
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsites": {
@@ -2652,8 +2662,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "camelcase": {
@@ -2668,9 +2678,9 @@
             "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0",
-                "map-obj": "2.0.0",
-                "quick-lru": "1.1.0"
+                "camelcase": "^4.1.0",
+                "map-obj": "^2.0.0",
+                "quick-lru": "^1.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -2687,10 +2697,10 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000847",
-                "lodash.memoize": "4.1.2",
-                "lodash.uniq": "4.5.0"
+                "browserslist": "^1.3.6",
+                "caniuse-db": "^1.0.30000529",
+                "lodash.memoize": "^4.1.2",
+                "lodash.uniq": "^4.5.0"
             },
             "dependencies": {
                 "browserslist": {
@@ -2699,8 +2709,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000847",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-db": "^1.0.30000639",
+                        "electron-to-chromium": "^1.2.7"
                     }
                 }
             }
@@ -2722,9 +2732,9 @@
             "resolved": "https://registry.npmjs.org/cardboard-vr-display/-/cardboard-vr-display-1.0.11.tgz",
             "integrity": "sha512-G63yklmd1fsce5nJL2LPcpFOSWMEGqjdWeNxowTPkYEpR41RtpBkebR8sjh7Z24rmID3MB7mFjZaIHvrKXCXFw==",
             "requires": {
-                "gl-preserve-state": "1.0.0",
-                "nosleep.js": "0.7.0",
-                "webvr-polyfill-dpdb": "1.0.7"
+                "gl-preserve-state": "^1.0.0",
+                "nosleep.js": "^0.7.0",
+                "webvr-polyfill-dpdb": "^1.0.7"
             }
         },
         "cardinal": {
@@ -2733,8 +2743,8 @@
             "integrity": "sha1-UOIcGwqjdyn5N33vGWtanOyTLuk=",
             "dev": true,
             "requires": {
-                "ansicolors": "0.2.1",
-                "redeyed": "1.0.1"
+                "ansicolors": "~0.2.1",
+                "redeyed": "~1.0.0"
             }
         },
         "center-align": {
@@ -2744,8 +2754,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chai": {
@@ -2754,12 +2764,12 @@
             "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
             "dev": true,
             "requires": {
-                "assertion-error": "1.1.0",
-                "check-error": "1.0.2",
-                "deep-eql": "3.0.1",
-                "get-func-name": "2.0.0",
-                "pathval": "1.1.0",
-                "type-detect": "4.0.8"
+                "assertion-error": "^1.0.1",
+                "check-error": "^1.0.1",
+                "deep-eql": "^3.0.0",
+                "get-func-name": "^2.0.0",
+                "pathval": "^1.0.0",
+                "type-detect": "^4.0.0"
             }
         },
         "chalk": {
@@ -2768,9 +2778,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "chardet": {
@@ -2797,18 +2807,18 @@
             "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.2",
-                "fsevents": "1.2.4",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.1.0"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             },
             "dependencies": {
                 "array-unique": {
@@ -2823,16 +2833,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     }
                 },
                 "extend-shallow": {
@@ -2841,7 +2851,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "fill-range": {
@@ -2850,10 +2860,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     }
                 },
                 "glob-parent": {
@@ -2862,8 +2872,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -2872,7 +2882,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -2883,7 +2893,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 },
                 "isobject": {
@@ -2918,8 +2928,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "circular-json": {
@@ -2934,7 +2944,7 @@
             "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3"
+                "chalk": "^1.1.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2949,11 +2959,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -2970,10 +2980,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2982,7 +2992,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "isobject": {
@@ -3004,7 +3014,7 @@
             "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "0.5.x"
             },
             "dependencies": {
                 "source-map": {
@@ -3027,7 +3037,7 @@
             "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
             "dev": true,
             "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
             }
         },
         "cli-spinners": {
@@ -3052,7 +3062,7 @@
             "dev": true,
             "requires": {
                 "slice-ansi": "0.0.4",
-                "string-width": "1.0.2"
+                "string-width": "^1.0.1"
             },
             "dependencies": {
                 "slice-ansi": {
@@ -3075,9 +3085,9 @@
             "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wrap-ansi": "2.1.0"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wrap-ansi": "^2.0.0"
             }
         },
         "clone": {
@@ -3098,7 +3108,7 @@
             "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
             "dev": true,
             "requires": {
-                "mimic-response": "1.0.0"
+                "mimic-response": "^1.0.0"
             }
         },
         "clone-stats": {
@@ -3113,9 +3123,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -3130,13 +3140,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -3145,7 +3155,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -3162,7 +3172,7 @@
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.1.2"
             }
         },
         "code-point-at": {
@@ -3177,8 +3187,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color": {
@@ -3187,9 +3197,9 @@
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "color-convert": "1.9.1",
-                "color-string": "0.3.0"
+                "clone": "^1.0.2",
+                "color-convert": "^1.3.0",
+                "color-string": "^0.3.0"
             }
         },
         "color-convert": {
@@ -3198,7 +3208,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -3213,7 +3223,7 @@
             "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.0.0"
             }
         },
         "colormin": {
@@ -3222,9 +3232,9 @@
             "integrity": "sha1-6i90IKcrlogaOKrlnsEkpvcpgTM=",
             "dev": true,
             "requires": {
-                "color": "0.11.4",
+                "color": "^0.11.0",
                 "css-color-names": "0.0.4",
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "colors": {
@@ -3244,14 +3254,14 @@
             "integrity": "sha1-wNAFNe8mTaf2Nzft/aQiiYP6IpE=",
             "dev": true,
             "requires": {
-                "cachedir": "1.2.0",
+                "cachedir": "^1.1.0",
                 "chalk": "1.1.3",
                 "cz-conventional-changelog": "1.2.0",
                 "dedent": "0.6.0",
                 "detect-indent": "4.0.0",
                 "find-node-modules": "1.0.4",
                 "find-root": "1.0.0",
-                "fs-extra": "1.0.0",
+                "fs-extra": "^1.0.0",
                 "glob": "7.1.1",
                 "inquirer": "1.2.3",
                 "lodash": "4.17.2",
@@ -3273,11 +3283,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "cz-conventional-changelog": {
@@ -3286,12 +3296,12 @@
                     "integrity": "sha1-K8oElkyJGbI/P9aonvXmAIsxs/g=",
                     "dev": true,
                     "requires": {
-                        "conventional-commit-types": "2.2.0",
-                        "lodash.map": "4.6.0",
-                        "longest": "1.0.1",
-                        "pad-right": "0.2.2",
-                        "right-pad": "1.0.1",
-                        "word-wrap": "1.2.3"
+                        "conventional-commit-types": "^2.0.0",
+                        "lodash.map": "^4.5.1",
+                        "longest": "^1.0.1",
+                        "pad-right": "^0.2.2",
+                        "right-pad": "^1.0.1",
+                        "word-wrap": "^1.0.3"
                     }
                 },
                 "fs-extra": {
@@ -3300,9 +3310,9 @@
                     "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "2.4.0",
-                        "klaw": "1.3.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^2.1.0",
+                        "klaw": "^1.0.0"
                     }
                 },
                 "glob": {
@@ -3311,12 +3321,12 @@
                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.2",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "jsonfile": {
@@ -3325,7 +3335,7 @@
                     "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "lodash": {
@@ -3346,7 +3356,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "shelljs": {
@@ -3355,9 +3365,9 @@
                     "integrity": "sha1-N5zM+1a5HIYB5HkzVutTgpJN6a0=",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.1",
-                        "interpret": "1.1.0",
-                        "rechoir": "0.6.2"
+                        "glob": "^7.0.0",
+                        "interpret": "^1.0.0",
+                        "rechoir": "^0.6.2"
                     }
                 },
                 "supports-color": {
@@ -3380,8 +3390,8 @@
             "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
             "dev": true,
             "requires": {
-                "array-ify": "1.0.0",
-                "dot-prop": "3.0.0"
+                "array-ify": "^1.0.0",
+                "dot-prop": "^3.0.0"
             }
         },
         "component-classes": {
@@ -3411,7 +3421,7 @@
             "integrity": "sha1-DRAgq5JLL9tNYnmHXH1tq6a6p6k=",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": ">= 1.33.0 < 2"
             }
         },
         "compression": {
@@ -3420,13 +3430,13 @@
             "integrity": "sha1-qv+81qr4VLROuygDU9WtFlH1mmk=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "bytes": "3.0.0",
-                "compressible": "2.0.13",
+                "compressible": "~2.0.13",
                 "debug": "2.6.9",
-                "on-headers": "1.0.1",
+                "on-headers": "~1.0.1",
                 "safe-buffer": "5.1.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "debug": {
@@ -3452,11 +3462,11 @@
             "integrity": "sha512-ZVWKrTQhtOP7rDx3M/koXTnRm/iwcYbuCdV+i4lZfAIe32Mov7vUVM0+8Vpz4q0xH+TBUZxq+rM8nhtkDH50YQ==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "neo-async": "2.5.1",
-                "serialize-javascript": "1.5.0",
-                "webpack-sources": "1.1.0"
+                "cacache": "^10.0.1",
+                "find-cache-dir": "^1.0.0",
+                "neo-async": "^2.5.0",
+                "serialize-javascript": "^1.4.0",
+                "webpack-sources": "^1.0.1"
             }
         },
         "concat-map": {
@@ -3470,10 +3480,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -3488,13 +3498,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -3503,7 +3513,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -3520,7 +3530,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "constants-browserify": {
@@ -3553,8 +3563,8 @@
             "integrity": "sha512-I1W7Vr/2AFlwhrjvjhp8Tz61qsRWc/dL96kgMmAwkJw/eVLLTokbuYnyYQ8k+/Loy2na8C18yD0SOkE/1AmIsw==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "q": "1.5.1"
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-writer": {
@@ -3563,16 +3573,16 @@
             "integrity": "sha512-n9KbsxlJxRQsUnK6wIBRnARacvNnN4C/nxnxCkH+B/R1JS2Fa+DiP1dU4I59mEDEjgnFaN2+9wr1P1s7GYB5/Q==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "conventional-commits-filter": "1.1.6",
-                "dateformat": "3.0.3",
-                "handlebars": "4.0.11",
-                "json-stringify-safe": "5.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "semver": "5.5.0",
-                "split": "1.0.1",
-                "through2": "2.0.3"
+                "compare-func": "^1.3.1",
+                "conventional-commits-filter": "^1.1.6",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.0.2",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "semver": "^5.5.0",
+                "split": "^1.0.0",
+                "through2": "^2.0.0"
             }
         },
         "conventional-commit-types": {
@@ -3587,8 +3597,8 @@
             "integrity": "sha512-KcDgtCRKJCQhyk6VLT7zR+ZOyCnerfemE/CsR3iQpzRRFbLEs0Y6rwk3mpDvtOh04X223z+1xyJ582Stfct/0Q==",
             "dev": true,
             "requires": {
-                "is-subset": "0.1.1",
-                "modify-values": "1.0.1"
+                "is-subset": "^0.1.1",
+                "modify-values": "^1.0.0"
             }
         },
         "conventional-commits-parser": {
@@ -3597,13 +3607,13 @@
             "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
-                "is-text-path": "1.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "split2": "2.2.0",
-                "through2": "2.0.3",
-                "trim-off-newlines": "1.0.1"
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
             }
         },
         "convert-source-map": {
@@ -3630,12 +3640,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
             }
         },
         "copy-descriptor": {
@@ -3650,14 +3660,14 @@
             "integrity": "sha512-OlTo6DYg0XfTKOF8eLf79wcHm4Ut10xU2cRBRPMW/NA5F9VMjZGTfRHWDIYC3s+1kObGYrBLshXWU1K0hILkNQ==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "globby": "7.1.1",
-                "is-glob": "4.0.0",
-                "loader-utils": "1.1.0",
-                "minimatch": "3.0.4",
-                "p-limit": "1.2.0",
-                "serialize-javascript": "1.5.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "globby": "^7.1.1",
+                "is-glob": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "minimatch": "^3.0.4",
+                "p-limit": "^1.0.0",
+                "serialize-javascript": "^1.4.0"
             }
         },
         "core-js": {
@@ -3682,13 +3692,13 @@
             "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
             "dev": true,
             "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.7.0",
-                "minimist": "1.2.0",
-                "object-assign": "4.1.1",
-                "os-homedir": "1.0.2",
-                "parse-json": "2.2.0",
-                "require-from-string": "1.2.1"
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.4.3",
+                "minimist": "^1.2.0",
+                "object-assign": "^4.1.0",
+                "os-homedir": "^1.0.1",
+                "parse-json": "^2.2.0",
+                "require-from-string": "^1.1.0"
             },
             "dependencies": {
                 "minimist": {
@@ -3705,8 +3715,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-hash": {
@@ -3715,11 +3725,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "md5.js": "1.3.4",
-                "ripemd160": "2.0.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -3728,12 +3738,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "create-react-class": {
@@ -3742,9 +3752,9 @@
             "integrity": "sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==",
             "dev": true,
             "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
+                "fbjs": "^0.8.9",
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
             }
         },
         "cross-spawn": {
@@ -3753,9 +3763,9 @@
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "shebang-command": "1.2.0",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "crypto-browserify": {
@@ -3764,17 +3774,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.1",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.3",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "diffie-hellman": "5.0.3",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.16",
-                "public-encrypt": "4.0.2",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css-animation": {
@@ -3783,8 +3793,8 @@
             "integrity": "sha1-W4gTEl3g+7uwu+G0cq6EIhRpt6g=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "component-classes": "1.2.6"
+                "babel-runtime": "6.x",
+                "component-classes": "^1.2.5"
             }
         },
         "css-color-names": {
@@ -3799,20 +3809,20 @@
             "integrity": "sha512-wovHgjAx8ZIMGSL8pTys7edA1ClmzxHeY6n/d97gg5odgsxEgKjULPR0viqyC+FWMCL9sfqoC/QCUBo62tLvPg==",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "css-selector-tokenizer": "0.7.0",
-                "cssnano": "3.10.0",
-                "icss-utils": "2.1.0",
-                "loader-utils": "1.1.0",
-                "lodash.camelcase": "4.3.0",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-modules-extract-imports": "1.2.0",
-                "postcss-modules-local-by-default": "1.2.0",
-                "postcss-modules-scope": "1.1.0",
-                "postcss-modules-values": "1.3.0",
-                "postcss-value-parser": "3.3.0",
-                "source-list-map": "2.0.0"
+                "babel-code-frame": "^6.26.0",
+                "css-selector-tokenizer": "^0.7.0",
+                "cssnano": "^3.10.0",
+                "icss-utils": "^2.1.0",
+                "loader-utils": "^1.0.2",
+                "lodash.camelcase": "^4.3.0",
+                "object-assign": "^4.1.1",
+                "postcss": "^5.0.6",
+                "postcss-modules-extract-imports": "^1.2.0",
+                "postcss-modules-local-by-default": "^1.2.0",
+                "postcss-modules-scope": "^1.1.0",
+                "postcss-modules-values": "^1.3.0",
+                "postcss-value-parser": "^3.3.0",
+                "source-list-map": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3827,11 +3837,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -3854,10 +3864,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -3872,7 +3882,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -3883,10 +3893,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             }
         },
         "css-selector-tokenizer": {
@@ -3895,9 +3905,9 @@
             "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
             "dev": true,
             "requires": {
-                "cssesc": "0.1.0",
-                "fastparse": "1.1.1",
-                "regexpu-core": "1.0.0"
+                "cssesc": "^0.1.0",
+                "fastparse": "^1.1.1",
+                "regexpu-core": "^1.0.0"
             },
             "dependencies": {
                 "regexpu-core": {
@@ -3906,9 +3916,9 @@
                     "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
                     "dev": true,
                     "requires": {
-                        "regenerate": "1.4.0",
-                        "regjsgen": "0.2.0",
-                        "regjsparser": "0.1.5"
+                        "regenerate": "^1.2.1",
+                        "regjsgen": "^0.2.0",
+                        "regjsparser": "^0.1.4"
                     }
                 }
             }
@@ -3919,8 +3929,8 @@
             "integrity": "sha512-XC6xLW/JqIGirnZuUWHXCHRaAjje2b3OIB0Vj5RIJo6mIi/AdJo30quQl5LxUl0gkXDIrTrFGbMlcZjyFplz1A==",
             "dev": true,
             "requires": {
-                "mdn-data": "1.1.3",
-                "source-map": "0.5.7"
+                "mdn-data": "^1.0.0",
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "source-map": {
@@ -3949,38 +3959,38 @@
             "integrity": "sha1-Tzj2zqK5sX+gFJDyPx3GjqZcHDg=",
             "dev": true,
             "requires": {
-                "autoprefixer": "6.7.7",
-                "decamelize": "1.2.0",
-                "defined": "1.0.0",
-                "has": "1.0.1",
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-calc": "5.3.1",
-                "postcss-colormin": "2.2.2",
-                "postcss-convert-values": "2.6.1",
-                "postcss-discard-comments": "2.0.4",
-                "postcss-discard-duplicates": "2.1.0",
-                "postcss-discard-empty": "2.1.0",
-                "postcss-discard-overridden": "0.1.1",
-                "postcss-discard-unused": "2.2.3",
-                "postcss-filter-plugins": "2.0.3",
-                "postcss-merge-idents": "2.1.7",
-                "postcss-merge-longhand": "2.0.2",
-                "postcss-merge-rules": "2.1.2",
-                "postcss-minify-font-values": "1.0.5",
-                "postcss-minify-gradients": "1.0.5",
-                "postcss-minify-params": "1.2.2",
-                "postcss-minify-selectors": "2.1.1",
-                "postcss-normalize-charset": "1.1.1",
-                "postcss-normalize-url": "3.0.8",
-                "postcss-ordered-values": "2.2.3",
-                "postcss-reduce-idents": "2.4.0",
-                "postcss-reduce-initial": "1.0.1",
-                "postcss-reduce-transforms": "1.0.4",
-                "postcss-svgo": "2.1.6",
-                "postcss-unique-selectors": "2.0.2",
-                "postcss-value-parser": "3.3.0",
-                "postcss-zindex": "2.2.0"
+                "autoprefixer": "^6.3.1",
+                "decamelize": "^1.1.2",
+                "defined": "^1.0.0",
+                "has": "^1.0.1",
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.14",
+                "postcss-calc": "^5.2.0",
+                "postcss-colormin": "^2.1.8",
+                "postcss-convert-values": "^2.3.4",
+                "postcss-discard-comments": "^2.0.4",
+                "postcss-discard-duplicates": "^2.0.1",
+                "postcss-discard-empty": "^2.0.1",
+                "postcss-discard-overridden": "^0.1.1",
+                "postcss-discard-unused": "^2.2.1",
+                "postcss-filter-plugins": "^2.0.0",
+                "postcss-merge-idents": "^2.1.5",
+                "postcss-merge-longhand": "^2.0.1",
+                "postcss-merge-rules": "^2.0.3",
+                "postcss-minify-font-values": "^1.0.2",
+                "postcss-minify-gradients": "^1.0.1",
+                "postcss-minify-params": "^1.0.4",
+                "postcss-minify-selectors": "^2.0.4",
+                "postcss-normalize-charset": "^1.1.0",
+                "postcss-normalize-url": "^3.0.7",
+                "postcss-ordered-values": "^2.1.0",
+                "postcss-reduce-idents": "^2.2.2",
+                "postcss-reduce-initial": "^1.0.0",
+                "postcss-reduce-transforms": "^1.0.3",
+                "postcss-svgo": "^2.1.1",
+                "postcss-unique-selectors": "^2.0.2",
+                "postcss-value-parser": "^3.2.3",
+                "postcss-zindex": "^2.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3995,12 +4005,12 @@
                     "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
                     "dev": true,
                     "requires": {
-                        "browserslist": "1.7.7",
-                        "caniuse-db": "1.0.30000847",
-                        "normalize-range": "0.1.2",
-                        "num2fraction": "1.2.2",
-                        "postcss": "5.2.18",
-                        "postcss-value-parser": "3.3.0"
+                        "browserslist": "^1.7.6",
+                        "caniuse-db": "^1.0.30000634",
+                        "normalize-range": "^0.1.2",
+                        "num2fraction": "^1.2.2",
+                        "postcss": "^5.2.16",
+                        "postcss-value-parser": "^3.2.3"
                     }
                 },
                 "browserslist": {
@@ -4009,8 +4019,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000847",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-db": "^1.0.30000639",
+                        "electron-to-chromium": "^1.2.7"
                     }
                 },
                 "chalk": {
@@ -4019,11 +4029,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -4046,10 +4056,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -4064,7 +4074,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -4075,8 +4085,8 @@
             "integrity": "sha1-3dUsWHAz9J6Utx/FVWnyUuj/X4U=",
             "dev": true,
             "requires": {
-                "clap": "1.2.3",
-                "source-map": "0.5.7"
+                "clap": "^1.0.9",
+                "source-map": "^0.5.3"
             },
             "dependencies": {
                 "source-map": {
@@ -4093,7 +4103,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "cyclist": {
@@ -4108,11 +4118,11 @@
             "integrity": "sha1-L0vHOQ4yROTfKT5ro1Hkx0Cnx2Q=",
             "dev": true,
             "requires": {
-                "conventional-commit-types": "2.2.0",
-                "lodash.map": "4.6.0",
-                "longest": "1.0.1",
-                "right-pad": "1.0.1",
-                "word-wrap": "1.2.3"
+                "conventional-commit-types": "^2.0.0",
+                "lodash.map": "^4.5.1",
+                "longest": "^1.0.1",
+                "right-pad": "^1.0.1",
+                "word-wrap": "^1.0.3"
             }
         },
         "d": {
@@ -4121,7 +4131,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.44"
+                "es5-ext": "^0.10.9"
             }
         },
         "damerau-levenshtein": {
@@ -4175,8 +4185,8 @@
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
             "dev": true,
             "requires": {
-                "decamelize": "1.2.0",
-                "map-obj": "1.0.1"
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "map-obj": {
@@ -4199,7 +4209,7 @@
             "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
             "dev": true,
             "requires": {
-                "mimic-response": "1.0.0"
+                "mimic-response": "^1.0.0"
             }
         },
         "dedent": {
@@ -4214,7 +4224,7 @@
             "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
             "dev": true,
             "requires": {
-                "type-detect": "4.0.8"
+                "type-detect": "^4.0.0"
             }
         },
         "deep-equal": {
@@ -4247,8 +4257,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.11"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -4257,8 +4267,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -4267,7 +4277,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4276,7 +4286,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4285,9 +4295,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -4316,13 +4326,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "globby": {
@@ -4331,12 +4341,12 @@
                     "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "arrify": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -4359,8 +4369,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -4381,7 +4391,7 @@
             "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
             "dev": true,
             "requires": {
-                "fs-exists-sync": "0.1.0"
+                "fs-exists-sync": "^0.1.0"
             }
         },
         "detect-indent": {
@@ -4390,7 +4400,7 @@
             "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
             "dev": true,
             "requires": {
-                "repeating": "2.0.1"
+                "repeating": "^2.0.0"
             }
         },
         "detect-newline": {
@@ -4417,9 +4427,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "dir-glob": {
@@ -4428,8 +4438,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             }
         },
         "dns-equal": {
@@ -4444,8 +4454,8 @@
             "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
             "dev": true,
             "requires": {
-                "ip": "1.1.5",
-                "safe-buffer": "5.1.2"
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
             }
         },
         "dns-txt": {
@@ -4454,7 +4464,7 @@
             "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
             "dev": true,
             "requires": {
-                "buffer-indexof": "1.1.1"
+                "buffer-indexof": "^1.0.0"
             }
         },
         "doctrine": {
@@ -4463,7 +4473,7 @@
             "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
             "dev": true,
             "requires": {
-                "esutils": "2.0.2"
+                "esutils": "^2.0.2"
             }
         },
         "dom-align": {
@@ -4478,7 +4488,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "0.3.3"
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -4500,8 +4510,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -4530,7 +4540,7 @@
             "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domready": {
@@ -4545,8 +4555,8 @@
             "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dot-prop": {
@@ -4555,7 +4565,7 @@
             "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer": {
@@ -4570,7 +4580,7 @@
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "duplexer3": {
@@ -4585,10 +4595,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecstatic": {
@@ -4597,10 +4607,10 @@
             "integrity": "sha512-ztE4WqheoWLh3wv+HQwy7dACnvNY620coWpa+XqY6R2cVWgaAT2lUISU1Uf7JpdLLJCURktJOaA9av2AOzsyYQ==",
             "dev": true,
             "requires": {
-                "he": "1.1.1",
-                "mime": "1.6.0",
-                "minimist": "1.2.0",
-                "url-join": "2.0.5"
+                "he": "^1.1.1",
+                "mime": "^1.2.11",
+                "minimist": "^1.1.0",
+                "url-join": "^2.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -4647,13 +4657,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "emoji-regex": {
@@ -4679,7 +4689,7 @@
             "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
             "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
             "requires": {
-                "iconv-lite": "0.4.23"
+                "iconv-lite": "~0.4.13"
             }
         },
         "end-of-stream": {
@@ -4688,7 +4698,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "enhanced-resolve": {
@@ -4697,9 +4707,9 @@
             "integrity": "sha1-TW5omzcl+GCQknzMhs2fFjW4ni4=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "memory-fs": "0.2.0",
-                "tapable": "0.1.10"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.2.0",
+                "tapable": "^0.1.8"
             }
         },
         "entities": {
@@ -4714,8 +4724,8 @@
             "integrity": "sha512-FyxH6t3kg8l2ha507BQYgTA3G7p4Xntx+TwjkNuBf96mKD1p/tTpaU3jJinCBzXUJb9zb+X/EyvaOiOHs2JVGA==",
             "dev": true,
             "requires": {
-                "execa": "0.10.0",
-                "java-properties": "0.2.10"
+                "execa": "^0.10.0",
+                "java-properties": "^0.2.9"
             }
         },
         "envinfo": {
@@ -4730,7 +4740,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
             }
         },
         "error": {
@@ -4739,8 +4749,8 @@
             "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
             "dev": true,
             "requires": {
-                "string-template": "0.2.1",
-                "xtend": "4.0.1"
+                "string-template": "~0.2.1",
+                "xtend": "~4.0.0"
             }
         },
         "error-ex": {
@@ -4749,7 +4759,7 @@
             "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -4758,11 +4768,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.1",
-                "is-callable": "1.1.3",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
             }
         },
         "es-to-primitive": {
@@ -4771,9 +4781,9 @@
             "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.3",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "is-callable": "^1.1.1",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.1"
             }
         },
         "es5-ext": {
@@ -4782,9 +4792,9 @@
             "integrity": "sha512-TO4Vt9IhW3FzDKLDOpoA8VS9BCV4b9WTf6BqvMOgfoa8wX73F3Kh3y2J7yTstTaXlQ0k1vq4DH2vw6RSs42z+g==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1",
-                "next-tick": "1.0.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
             }
         },
         "es6-iterator": {
@@ -4793,9 +4803,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.44",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-object-assign": {
@@ -4815,7 +4825,7 @@
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
-                "es6-promise": "4.2.4"
+                "es6-promise": "^4.0.3"
             },
             "dependencies": {
                 "es6-promise": {
@@ -4832,8 +4842,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.44"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "es6-templates": {
@@ -4842,8 +4852,8 @@
             "integrity": "sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=",
             "dev": true,
             "requires": {
-                "recast": "0.11.23",
-                "through": "2.3.8"
+                "recast": "~0.11.12",
+                "through": "~2.3.6"
             }
         },
         "escape-html": {
@@ -4864,44 +4874,44 @@
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "babel-code-frame": "6.26.0",
-                "chalk": "2.4.1",
-                "concat-stream": "1.6.2",
-                "cross-spawn": "5.1.0",
-                "debug": "3.1.0",
-                "doctrine": "2.1.0",
-                "eslint-scope": "3.7.1",
-                "eslint-visitor-keys": "1.0.0",
-                "espree": "3.5.4",
-                "esquery": "1.0.1",
-                "esutils": "2.0.2",
-                "file-entry-cache": "2.0.0",
-                "functional-red-black-tree": "1.0.1",
-                "glob": "7.1.2",
-                "globals": "11.5.0",
-                "ignore": "3.3.8",
-                "imurmurhash": "0.1.4",
-                "inquirer": "3.3.0",
-                "is-resolvable": "1.1.0",
-                "js-yaml": "3.11.0",
-                "json-stable-stringify-without-jsonify": "1.0.1",
-                "levn": "0.3.0",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "natural-compare": "1.4.0",
-                "optionator": "0.8.2",
-                "path-is-inside": "1.0.2",
-                "pluralize": "7.0.0",
-                "progress": "2.0.0",
-                "regexpp": "1.1.0",
-                "require-uncached": "1.0.3",
-                "semver": "5.5.0",
-                "strip-ansi": "4.0.0",
-                "strip-json-comments": "2.0.1",
+                "ajv": "^5.3.0",
+                "babel-code-frame": "^6.22.0",
+                "chalk": "^2.1.0",
+                "concat-stream": "^1.6.0",
+                "cross-spawn": "^5.1.0",
+                "debug": "^3.1.0",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^3.7.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^3.5.4",
+                "esquery": "^1.0.0",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.0.1",
+                "ignore": "^3.3.3",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^3.0.6",
+                "is-resolvable": "^1.0.0",
+                "js-yaml": "^3.9.1",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^1.0.1",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.3.0",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "~2.0.1",
                 "table": "4.0.2",
-                "text-table": "0.2.0"
+                "text-table": "~0.2.0"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -4922,7 +4932,7 @@
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "2.0.0"
+                        "restore-cursor": "^2.0.0"
                     }
                 },
                 "esprima": {
@@ -4937,9 +4947,9 @@
                     "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
                     "dev": true,
                     "requires": {
-                        "chardet": "0.4.2",
-                        "iconv-lite": "0.4.23",
-                        "tmp": "0.0.33"
+                        "chardet": "^0.4.0",
+                        "iconv-lite": "^0.4.17",
+                        "tmp": "^0.0.33"
                     }
                 },
                 "figures": {
@@ -4948,7 +4958,7 @@
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
                     "dev": true,
                     "requires": {
-                        "escape-string-regexp": "1.0.5"
+                        "escape-string-regexp": "^1.0.5"
                     }
                 },
                 "globals": {
@@ -4963,20 +4973,20 @@
                     "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.1",
-                        "cli-cursor": "2.1.0",
-                        "cli-width": "2.2.0",
-                        "external-editor": "2.2.0",
-                        "figures": "2.0.0",
-                        "lodash": "4.17.10",
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.0",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^2.0.4",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.3.0",
                         "mute-stream": "0.0.7",
-                        "run-async": "2.3.0",
-                        "rx-lite": "4.0.8",
-                        "rx-lite-aggregates": "4.0.8",
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "through": "2.3.8"
+                        "run-async": "^2.2.0",
+                        "rx-lite": "^4.0.8",
+                        "rx-lite-aggregates": "^4.0.8",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "through": "^2.3.6"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -4991,8 +5001,8 @@
                     "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "mute-stream": {
@@ -5007,7 +5017,7 @@
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "restore-cursor": {
@@ -5016,8 +5026,8 @@
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
                     "dev": true,
                     "requires": {
-                        "onetime": "2.0.1",
-                        "signal-exit": "3.0.2"
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "string-width": {
@@ -5026,8 +5036,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -5036,7 +5046,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "tmp": {
@@ -5045,7 +5055,7 @@
                     "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.2"
                     }
                 }
             }
@@ -5056,7 +5066,7 @@
             "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
             "dev": true,
             "requires": {
-                "eslint-config-airbnb-base": "12.1.0"
+                "eslint-config-airbnb-base": "^12.1.0"
             }
         },
         "eslint-config-airbnb-base": {
@@ -5065,7 +5075,7 @@
             "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
             "dev": true,
             "requires": {
-                "eslint-restricted-globals": "0.1.1"
+                "eslint-restricted-globals": "^0.1.1"
             }
         },
         "eslint-config-prettier": {
@@ -5074,7 +5084,7 @@
             "integrity": "sha512-ag8YEyBXsm3nmOv1Hz991VtNNDMRa+MNy8cY47Pl4bw6iuzqKbJajXdqUpiw13STdLLrznxgm1hj9NhxeOYq0A==",
             "dev": true,
             "requires": {
-                "get-stdin": "5.0.1"
+                "get-stdin": "^5.0.1"
             }
         },
         "eslint-import-resolver-node": {
@@ -5083,8 +5093,8 @@
             "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "resolve": "1.7.1"
+                "debug": "^2.6.9",
+                "resolve": "^1.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -5104,17 +5114,17 @@
             "integrity": "sha1-IxzhV4rVEk2leZ8Cm9M9KBN2I+M=",
             "dev": true,
             "requires": {
-                "array-find": "1.0.0",
-                "debug": "2.6.9",
-                "enhanced-resolve": "0.9.1",
-                "find-root": "1.1.0",
-                "has": "1.0.1",
-                "interpret": "1.1.0",
-                "is-absolute": "0.2.6",
-                "lodash.get": "4.4.2",
-                "node-libs-browser": "2.1.0",
-                "resolve": "1.7.1",
-                "semver": "5.5.0"
+                "array-find": "^1.0.0",
+                "debug": "^2.6.8",
+                "enhanced-resolve": "~0.9.0",
+                "find-root": "^1.1.0",
+                "has": "^1.0.1",
+                "interpret": "^1.0.0",
+                "is-absolute": "^0.2.3",
+                "lodash.get": "^4.4.2",
+                "node-libs-browser": "^1.0.0 || ^2.0.0",
+                "resolve": "^1.4.0",
+                "semver": "^5.3.0"
             },
             "dependencies": {
                 "debug": {
@@ -5140,11 +5150,11 @@
             "integrity": "sha512-VxxGDI4bXzLk0+/jMt/0EkGMRKS9ox6Czx+yapMb9WJmcS/ZHhlhqcVUNgUjFBNp02j/2pZLdGOrG7EXyjoz/g==",
             "dev": true,
             "requires": {
-                "loader-fs-cache": "1.0.1",
-                "loader-utils": "1.1.0",
-                "object-assign": "4.1.1",
-                "object-hash": "1.3.0",
-                "rimraf": "2.6.2"
+                "loader-fs-cache": "^1.0.0",
+                "loader-utils": "^1.0.2",
+                "object-assign": "^4.0.1",
+                "object-hash": "^1.1.4",
+                "rimraf": "^2.6.1"
             }
         },
         "eslint-module-utils": {
@@ -5153,8 +5163,8 @@
             "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "pkg-dir": "1.0.0"
+                "debug": "^2.6.8",
+                "pkg-dir": "^1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -5172,8 +5182,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-exists": {
@@ -5182,7 +5192,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pkg-dir": {
@@ -5191,7 +5201,7 @@
                     "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2"
+                        "find-up": "^1.0.0"
                     }
                 }
             }
@@ -5202,16 +5212,16 @@
             "integrity": "sha1-+gkIPVp1KI35xsfQn+EiVZhWVec=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1",
-                "contains-path": "0.1.0",
-                "debug": "2.6.9",
+                "builtin-modules": "^1.1.1",
+                "contains-path": "^0.1.0",
+                "debug": "^2.6.8",
                 "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "0.3.2",
-                "eslint-module-utils": "2.2.0",
-                "has": "1.0.1",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "read-pkg-up": "2.0.0"
+                "eslint-import-resolver-node": "^0.3.1",
+                "eslint-module-utils": "^2.2.0",
+                "has": "^1.0.1",
+                "lodash": "^4.17.4",
+                "minimatch": "^3.0.3",
+                "read-pkg-up": "^2.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -5229,8 +5239,8 @@
                     "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
                     "dev": true,
                     "requires": {
-                        "esutils": "2.0.2",
-                        "isarray": "1.0.0"
+                        "esutils": "^2.0.2",
+                        "isarray": "^1.0.0"
                     }
                 }
             }
@@ -5241,13 +5251,13 @@
             "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
             "dev": true,
             "requires": {
-                "aria-query": "0.7.1",
-                "array-includes": "3.0.3",
+                "aria-query": "^0.7.0",
+                "array-includes": "^3.0.3",
                 "ast-types-flow": "0.0.7",
-                "axobject-query": "0.1.0",
-                "damerau-levenshtein": "1.0.4",
-                "emoji-regex": "6.5.1",
-                "jsx-ast-utils": "2.0.1"
+                "axobject-query": "^0.1.0",
+                "damerau-levenshtein": "^1.0.0",
+                "emoji-regex": "^6.1.0",
+                "jsx-ast-utils": "^2.0.0"
             }
         },
         "eslint-plugin-prettier": {
@@ -5256,8 +5266,8 @@
             "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
             "dev": true,
             "requires": {
-                "fast-diff": "1.1.2",
-                "jest-docblock": "21.2.0"
+                "fast-diff": "^1.1.1",
+                "jest-docblock": "^21.0.0"
             }
         },
         "eslint-plugin-react": {
@@ -5266,10 +5276,10 @@
             "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
             "dev": true,
             "requires": {
-                "doctrine": "2.1.0",
-                "has": "1.0.1",
-                "jsx-ast-utils": "2.0.1",
-                "prop-types": "15.6.1"
+                "doctrine": "^2.0.2",
+                "has": "^1.0.1",
+                "jsx-ast-utils": "^2.0.1",
+                "prop-types": "^15.6.0"
             }
         },
         "eslint-restricted-globals": {
@@ -5284,8 +5294,8 @@
             "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "eslint-visitor-keys": {
@@ -5300,8 +5310,8 @@
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
-                "acorn": "5.6.0",
-                "acorn-jsx": "3.0.1"
+                "acorn": "^5.5.0",
+                "acorn-jsx": "^3.0.0"
             }
         },
         "esprima": {
@@ -5316,7 +5326,7 @@
             "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.0.0"
             }
         },
         "esrecurse": {
@@ -5325,7 +5335,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -5364,7 +5374,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": "1.0.1"
+                "original": ">=0.0.5"
             }
         },
         "evp_bytestokey": {
@@ -5373,8 +5383,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.2"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "execa": {
@@ -5383,13 +5393,13 @@
             "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
             "dev": true,
             "requires": {
-                "cross-spawn": "6.0.5",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -5398,11 +5408,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 }
             }
@@ -5425,7 +5435,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -5434,7 +5444,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "expand-tilde": {
@@ -5443,7 +5453,7 @@
             "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.1"
             }
         },
         "exports-loader": {
@@ -5452,7 +5462,7 @@
             "integrity": "sha512-RKwCrO4A6IiKm0pG3c9V46JxIHcDplwwGJn6+JJ1RcVnh/WSGJa0xkmk5cRVtgOPzCAtTMGj2F7nluh9L0vpSA==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
+                "loader-utils": "^1.1.0",
                 "source-map": "0.5.0"
             },
             "dependencies": {
@@ -5476,36 +5486,36 @@
             "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.3",
+                "proxy-addr": "~2.0.3",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0",
-                "type-is": "1.6.16",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "debug": {
@@ -5543,8 +5553,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5553,7 +5563,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5564,9 +5574,9 @@
             "integrity": "sha1-Etew24UPf/fnCBuvQAVwAGDEYAs=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "spawn-sync": "1.0.15",
-                "tmp": "0.0.29"
+                "extend": "^3.0.0",
+                "spawn-sync": "^1.0.15",
+                "tmp": "^0.0.29"
             }
         },
         "extglob": {
@@ -5575,7 +5585,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -5604,12 +5614,12 @@
             "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
             "dev": true,
             "requires": {
-                "@mrmlnc/readdir-enhanced": "2.2.1",
-                "@nodelib/fs.stat": "1.1.0",
-                "glob-parent": "3.1.0",
-                "is-glob": "4.0.0",
-                "merge2": "1.2.2",
-                "micromatch": "3.1.10"
+                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                "@nodelib/fs.stat": "^1.0.1",
+                "glob-parent": "^3.1.0",
+                "is-glob": "^4.0.0",
+                "merge2": "^1.2.1",
+                "micromatch": "^3.1.10"
             },
             "dependencies": {
                 "arr-diff": {
@@ -5630,16 +5640,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -5648,7 +5658,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -5668,13 +5678,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -5683,7 +5693,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -5692,7 +5702,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -5701,7 +5711,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -5710,7 +5720,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -5721,7 +5731,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -5730,7 +5740,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -5741,9 +5751,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -5760,14 +5770,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -5776,7 +5786,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -5785,7 +5795,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -5796,10 +5806,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -5808,7 +5818,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -5819,8 +5829,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -5829,7 +5839,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -5840,7 +5850,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -5849,7 +5859,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -5858,9 +5868,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -5869,7 +5879,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -5878,7 +5888,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -5901,19 +5911,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -5942,7 +5952,7 @@
             "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
             "dev": true,
             "requires": {
-                "websocket-driver": "0.7.0"
+                "websocket-driver": ">=0.5.1"
             }
         },
         "fbjs": {
@@ -5950,13 +5960,13 @@
             "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
             "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
             "requires": {
-                "core-js": "1.2.7",
-                "isomorphic-fetch": "2.2.1",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "promise": "7.3.1",
-                "setimmediate": "1.0.5",
-                "ua-parser-js": "0.7.18"
+                "core-js": "^1.0.0",
+                "isomorphic-fetch": "^2.1.1",
+                "loose-envify": "^1.0.0",
+                "object-assign": "^4.1.0",
+                "promise": "^7.1.1",
+                "setimmediate": "^1.0.5",
+                "ua-parser-js": "^0.7.9"
             },
             "dependencies": {
                 "core-js": {
@@ -5972,8 +5982,8 @@
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
             }
         },
         "file-entry-cache": {
@@ -5982,8 +5992,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "file-loader": {
@@ -5992,8 +6002,8 @@
             "integrity": "sha512-TGR4HU7HUsGg6GCOPJnFk06RhWgEWFLAGWiT6rcD+GRC2keU3s9RGJ+b3Z6/U73jwwNb2gKLJ7YCrp+jvU4ALg==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.4.5"
+                "loader-utils": "^1.0.2",
+                "schema-utils": "^0.4.5"
             }
         },
         "filename-regex": {
@@ -6014,11 +6024,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "finalhandler": {
@@ -6028,12 +6038,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.4.0",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.4.0",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -6053,9 +6063,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "1.3.0",
-                "pkg-dir": "2.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
             }
         },
         "find-node-modules": {
@@ -6065,7 +6075,7 @@
             "dev": true,
             "requires": {
                 "findup-sync": "0.4.2",
-                "merge": "1.2.0"
+                "merge": "^1.2.0"
             }
         },
         "find-root": {
@@ -6080,7 +6090,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -6089,10 +6099,10 @@
             "integrity": "sha1-qBF9D3MST1pFRoOVef5S1xKfteU=",
             "dev": true,
             "requires": {
-                "detect-file": "0.1.0",
-                "is-glob": "2.0.1",
-                "micromatch": "2.3.11",
-                "resolve-dir": "0.1.1"
+                "detect-file": "^0.1.0",
+                "is-glob": "^2.0.1",
+                "micromatch": "^2.3.7",
+                "resolve-dir": "^0.1.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -6107,7 +6117,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -6118,7 +6128,7 @@
             "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "flat-cache": {
@@ -6127,10 +6137,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             }
         },
         "flatten": {
@@ -6151,8 +6161,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "follow-redirects": {
@@ -6161,7 +6171,7 @@
             "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             }
         },
         "font-awesome": {
@@ -6181,7 +6191,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -6202,7 +6212,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -6217,8 +6227,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-copy-file-sync": {
@@ -6239,9 +6249,9 @@
             "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "3.0.1",
-                "universalify": "0.1.1"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -6250,10 +6260,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.0.6"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
             }
         },
         "fs.realpath": {
@@ -6268,8 +6278,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.10.0"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -6295,8 +6305,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -6309,7 +6319,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -6373,7 +6383,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -6388,14 +6398,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -6404,12 +6414,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -6424,7 +6434,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -6433,7 +6443,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -6442,8 +6452,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -6462,7 +6472,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -6476,7 +6486,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -6489,8 +6499,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -6499,7 +6509,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -6522,9 +6532,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -6533,16 +6543,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -6551,8 +6561,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -6567,8 +6577,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -6577,10 +6587,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -6599,7 +6609,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -6620,8 +6630,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -6642,10 +6652,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -6662,13 +6672,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -6677,7 +6687,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -6720,9 +6730,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -6731,7 +6741,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -6739,7 +6749,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -6754,13 +6764,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -6775,7 +6785,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -6838,8 +6848,8 @@
             "integrity": "sha512-F/mS+fsWQMo1zfgG9MD8KWvTWPPzzhuVwY++fhQ5Ggd+0P+CAMHtzMZhNxG+TqGfHDChJKsbh6otfMGqO2AKBw==",
             "dev": true,
             "requires": {
-                "got": "7.1.0",
-                "is-plain-obj": "1.1.0"
+                "got": "^7.0.0",
+                "is-plain-obj": "^1.1.0"
             },
             "dependencies": {
                 "got": {
@@ -6848,20 +6858,20 @@
                     "integrity": "sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==",
                     "dev": true,
                     "requires": {
-                        "decompress-response": "3.3.0",
-                        "duplexer3": "0.1.4",
-                        "get-stream": "3.0.0",
-                        "is-plain-obj": "1.1.0",
-                        "is-retry-allowed": "1.1.0",
-                        "is-stream": "1.1.0",
-                        "isurl": "1.0.0",
-                        "lowercase-keys": "1.0.1",
-                        "p-cancelable": "0.3.0",
-                        "p-timeout": "1.2.1",
-                        "safe-buffer": "5.1.2",
-                        "timed-out": "4.0.1",
-                        "url-parse-lax": "1.0.0",
-                        "url-to-options": "1.0.1"
+                        "decompress-response": "^3.2.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-plain-obj": "^1.1.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "isurl": "^1.0.0-alpha5",
+                        "lowercase-keys": "^1.0.0",
+                        "p-cancelable": "^0.3.0",
+                        "p-timeout": "^1.1.1",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "url-parse-lax": "^1.0.0",
+                        "url-to-options": "^1.0.1"
                     }
                 },
                 "p-cancelable": {
@@ -6876,7 +6886,7 @@
                     "integrity": "sha1-XrOzU7f86Z8QGhA4iAuwVOu+o4Y=",
                     "dev": true,
                     "requires": {
-                        "p-finally": "1.0.0"
+                        "p-finally": "^1.0.0"
                     }
                 },
                 "url-parse-lax": {
@@ -6885,7 +6895,7 @@
                     "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
                     "dev": true,
                     "requires": {
-                        "prepend-http": "1.0.4"
+                        "prepend-http": "^1.0.1"
                     }
                 }
             }
@@ -6897,12 +6907,12 @@
             "dev": true,
             "requires": {
                 "async": "2.1.4",
-                "base64url": "2.0.0",
+                "base64url": "^2.0.0",
                 "commander": "2.9.0",
-                "fs-extra": "3.0.1",
-                "globby": "6.1.0",
+                "fs-extra": "^3.0.1",
+                "globby": "^6.1.0",
                 "graceful-fs": "4.1.11",
-                "rimraf": "2.6.2"
+                "rimraf": "^2.5.4"
             },
             "dependencies": {
                 "async": {
@@ -6911,7 +6921,7 @@
                     "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "commander": {
@@ -6920,7 +6930,7 @@
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                     }
                 },
                 "globby": {
@@ -6929,11 +6939,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -6950,12 +6960,12 @@
             "integrity": "sha1-LmpMGxP8AAKCB7p5WnrDFme5/Uo=",
             "dev": true,
             "requires": {
-                "argv-formatter": "1.0.0",
-                "spawn-error-forwarder": "1.0.0",
-                "split2": "1.0.0",
-                "stream-combiner2": "1.1.1",
-                "through2": "2.0.3",
-                "traverse": "0.6.6"
+                "argv-formatter": "~1.0.0",
+                "spawn-error-forwarder": "~1.0.0",
+                "split2": "~1.0.0",
+                "stream-combiner2": "~1.1.1",
+                "through2": "~2.0.0",
+                "traverse": "~0.6.6"
             },
             "dependencies": {
                 "split2": {
@@ -6964,7 +6974,7 @@
                     "integrity": "sha1-UuLiIdiMdfmnP5BVbiY/+WdysxQ=",
                     "dev": true,
                     "requires": {
-                        "through2": "2.0.3"
+                        "through2": "~2.0.0"
                     }
                 }
             }
@@ -6975,8 +6985,8 @@
             "integrity": "sha512-2v4UN3qV2RGypD9QpmUjpk+4+RlYpW8GFuiZqQnKmvei08HsFPd0RfbDvEhnE4wBvnYs8ORVtYpOFuuCEmBVBw==",
             "dev": true,
             "requires": {
-                "is-ssh": "1.3.0",
-                "parse-url": "1.3.11"
+                "is-ssh": "^1.3.0",
+                "parse-url": "^1.3.0"
             }
         },
         "git-url-parse": {
@@ -6985,8 +6995,8 @@
             "integrity": "sha512-r/FxXIdfgdSO+V2zl4ZK1JGYkHT9nqVRSzom5WsYPLg3XzeBeKPl3R/6X9E9ZJRx/sE/dXwXtfl+Zp7YL8ktWQ==",
             "dev": true,
             "requires": {
-                "git-up": "2.0.10",
-                "parse-domain": "2.1.1"
+                "git-up": "^2.0.0",
+                "parse-domain": "^2.0.0"
             }
         },
         "github-username": {
@@ -6995,7 +7005,7 @@
             "integrity": "sha1-y+KABBiDIG2kISrp5LXxacML9Bc=",
             "dev": true,
             "requires": {
-                "gh-got": "6.0.0"
+                "gh-got": "^6.0.0"
             }
         },
         "gl-matrix": {
@@ -7013,12 +7023,12 @@
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-all": {
@@ -7027,8 +7037,8 @@
             "integrity": "sha1-iRPd+17hrHgSZWJBsD1SF8ZLAqs=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "yargs": "1.2.6"
+                "glob": "^7.0.5",
+                "yargs": "~1.2.6"
             },
             "dependencies": {
                 "minimist": {
@@ -7043,7 +7053,7 @@
                     "integrity": "sha1-nHtKgv1dWVsr8Xq23MQxNUMv40s=",
                     "dev": true,
                     "requires": {
-                        "minimist": "0.1.0"
+                        "minimist": "^0.1.0"
                     }
                 }
             }
@@ -7054,8 +7064,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -7070,7 +7080,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -7081,7 +7091,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -7096,7 +7106,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -7113,8 +7123,8 @@
             "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
             "dev": true,
             "requires": {
-                "global-prefix": "0.1.5",
-                "is-windows": "0.2.0"
+                "global-prefix": "^0.1.4",
+                "is-windows": "^0.2.0"
             }
         },
         "global-prefix": {
@@ -7123,10 +7133,10 @@
             "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "0.2.0",
-                "which": "1.3.1"
+                "homedir-polyfill": "^1.0.0",
+                "ini": "^1.3.4",
+                "is-windows": "^0.2.0",
+                "which": "^1.2.12"
             }
         },
         "globals": {
@@ -7141,12 +7151,12 @@
             "integrity": "sha1-+yzP+UAfhgCUXfral0QMypcrhoA=",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "dir-glob": "2.0.0",
-                "glob": "7.1.2",
-                "ignore": "3.3.8",
-                "pify": "3.0.0",
-                "slash": "1.0.0"
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
             }
         },
         "got": {
@@ -7155,23 +7165,23 @@
             "integrity": "sha512-tiLX+bnYm5A56T5N/n9Xo89vMaO1mrS9qoDqj3u/anVooqGozvY/HbXzEpDfbNeKsHCBpK40gSbz8wGYSp3i1w==",
             "dev": true,
             "requires": {
-                "@sindresorhus/is": "0.7.0",
-                "cacheable-request": "2.1.4",
-                "decompress-response": "3.3.0",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "into-stream": "3.1.0",
-                "is-retry-allowed": "1.1.0",
-                "isurl": "1.0.0",
-                "lowercase-keys": "1.0.1",
-                "mimic-response": "1.0.0",
-                "p-cancelable": "0.4.1",
-                "p-timeout": "2.0.1",
-                "pify": "3.0.0",
-                "safe-buffer": "5.1.2",
-                "timed-out": "4.0.1",
-                "url-parse-lax": "3.0.0",
-                "url-to-options": "1.0.1"
+                "@sindresorhus/is": "^0.7.0",
+                "cacheable-request": "^2.1.1",
+                "decompress-response": "^3.3.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "into-stream": "^3.1.0",
+                "is-retry-allowed": "^1.1.0",
+                "isurl": "^1.0.0-alpha5",
+                "lowercase-keys": "^1.0.0",
+                "mimic-response": "^1.0.0",
+                "p-cancelable": "^0.4.0",
+                "p-timeout": "^2.0.1",
+                "pify": "^3.0.0",
+                "safe-buffer": "^5.1.1",
+                "timed-out": "^4.0.1",
+                "url-parse-lax": "^3.0.0",
+                "url-to-options": "^1.0.1"
             }
         },
         "graceful-fs": {
@@ -7192,7 +7202,7 @@
             "integrity": "sha1-wWfSpTGcWg4JZO9qJbfC34mWyFw=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.17.2"
             }
         },
         "growl": {
@@ -7207,8 +7217,8 @@
             "integrity": "sha1-iuCWJX6r59acRb4rZ8RIEk/7UXw=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "pify": "3.0.0"
+                "duplexer": "^0.1.1",
+                "pify": "^3.0.0"
             }
         },
         "hammerjs": {
@@ -7229,10 +7239,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "camelcase": {
@@ -7249,8 +7259,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     }
                 },
@@ -7260,7 +7270,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "uglify-js": {
@@ -7270,9 +7280,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -7305,9 +7315,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -7325,7 +7335,7 @@
             "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.0.2"
             }
         },
         "has-ansi": {
@@ -7334,7 +7344,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-color": {
@@ -7367,7 +7377,7 @@
             "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
             "dev": true,
             "requires": {
-                "has-symbol-support-x": "1.4.2"
+                "has-symbol-support-x": "^1.4.1"
             }
         },
         "has-value": {
@@ -7376,9 +7386,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -7395,8 +7405,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -7405,7 +7415,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7414,7 +7424,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -7425,7 +7435,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -7436,8 +7446,8 @@
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "hash.js": {
@@ -7446,8 +7456,8 @@
             "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "he": {
@@ -7462,9 +7472,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "home-or-tmp": {
@@ -7473,8 +7483,8 @@
             "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.1"
             }
         },
         "homedir-polyfill": {
@@ -7483,7 +7493,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hook-std": {
@@ -7504,10 +7514,10 @@
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "obuf": "1.1.2",
-                "readable-stream": "2.0.6",
-                "wbuf": "1.7.3"
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
             }
         },
         "hson-loader": {
@@ -7516,7 +7526,7 @@
             "integrity": "sha1-CKVAj5A67HXr9qJUATcFJXZ2pPk=",
             "dev": true,
             "requires": {
-                "hanson": "1.2.0"
+                "hanson": "^1.2.0"
             }
         },
         "html-comment-regex": {
@@ -7537,11 +7547,11 @@
             "integrity": "sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==",
             "dev": true,
             "requires": {
-                "es6-templates": "0.2.3",
-                "fastparse": "1.1.1",
-                "html-minifier": "3.5.16",
-                "loader-utils": "1.1.0",
-                "object-assign": "4.1.1"
+                "es6-templates": "^0.2.3",
+                "fastparse": "^1.1.1",
+                "html-minifier": "^3.5.8",
+                "loader-utils": "^1.1.0",
+                "object-assign": "^4.1.1"
             }
         },
         "html-minifier": {
@@ -7550,13 +7560,13 @@
             "integrity": "sha512-zP5EfLSpiLRp0aAgud4CQXPQZm9kXwWjR/cF0PfdOj+jjWnOaCgeZcll4kYXSvIBPeUMmyaSc7mM4IDtA+kboA==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.1.11",
-                "commander": "2.15.1",
-                "he": "1.1.1",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.3.28"
+                "camel-case": "3.0.x",
+                "clean-css": "4.1.x",
+                "commander": "2.15.x",
+                "he": "1.1.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.3.x"
             },
             "dependencies": {
                 "commander": {
@@ -7573,12 +7583,12 @@
             "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
             "dev": true,
             "requires": {
-                "html-minifier": "3.5.16",
-                "loader-utils": "0.2.17",
-                "lodash": "4.17.10",
-                "pretty-error": "2.1.1",
-                "tapable": "1.0.0",
-                "toposort": "1.0.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "tapable": "^1.0.0",
+                "toposort": "^1.0.0",
                 "util.promisify": "1.0.0"
             },
             "dependencies": {
@@ -7588,10 +7598,10 @@
                     "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1",
-                        "object-assign": "4.1.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0",
+                        "object-assign": "^4.0.1"
                     }
                 },
                 "tapable": {
@@ -7608,10 +7618,10 @@
             "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.1.0",
-                "domutils": "1.1.6",
-                "readable-stream": "1.0.34"
+                "domelementtype": "1",
+                "domhandler": "2.1",
+                "domutils": "1.1",
+                "readable-stream": "1.0"
             },
             "dependencies": {
                 "domutils": {
@@ -7620,7 +7630,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "isarray": {
@@ -7635,10 +7645,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 }
             }
@@ -7661,10 +7671,10 @@
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "dev": true,
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0"
+                "statuses": ">= 1.4.0 < 2"
             }
         },
         "http-parser-js": {
@@ -7679,9 +7689,9 @@
             "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "3.1.0",
-                "follow-redirects": "1.5.0",
-                "requires-port": "1.0.0"
+                "eventemitter3": "^3.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "http-proxy-agent": {
@@ -7690,7 +7700,7 @@
             "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
             "dev": true,
             "requires": {
-                "agent-base": "4.2.0",
+                "agent-base": "4",
                 "debug": "3.1.0"
             }
         },
@@ -7700,10 +7710,10 @@
             "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
-                "http-proxy": "1.17.0",
-                "is-glob": "4.0.0",
-                "lodash": "4.17.10",
-                "micromatch": "3.1.10"
+                "http-proxy": "^1.16.2",
+                "is-glob": "^4.0.0",
+                "lodash": "^4.17.5",
+                "micromatch": "^3.1.9"
             },
             "dependencies": {
                 "arr-diff": {
@@ -7724,16 +7734,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -7742,7 +7752,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -7762,13 +7772,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -7777,7 +7787,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -7786,7 +7796,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -7795,7 +7805,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -7804,7 +7814,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -7815,7 +7825,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -7824,7 +7834,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -7835,9 +7845,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -7854,14 +7864,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -7870,7 +7880,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -7879,7 +7889,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -7890,10 +7900,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -7902,7 +7912,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -7913,7 +7923,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -7922,7 +7932,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -7931,9 +7941,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -7942,7 +7952,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -7951,7 +7961,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -7974,19 +7984,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -7998,13 +8008,13 @@
             "dev": true,
             "requires": {
                 "colors": "1.0.3",
-                "corser": "2.0.1",
-                "ecstatic": "2.2.1",
-                "http-proxy": "1.17.0",
-                "opener": "1.4.3",
-                "optimist": "0.6.1",
-                "portfinder": "1.0.13",
-                "union": "0.4.6"
+                "corser": "~2.0.0",
+                "ecstatic": "^2.0.0",
+                "http-proxy": "^1.8.1",
+                "opener": "~1.4.0",
+                "optimist": "0.6.x",
+                "portfinder": "^1.0.13",
+                "union": "~0.4.3"
             }
         },
         "https-browserify": {
@@ -8019,8 +8029,8 @@
             "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
             "dev": true,
             "requires": {
-                "agent-base": "4.2.0",
-                "debug": "3.1.0"
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
             }
         },
         "iconv-lite": {
@@ -8028,7 +8038,7 @@
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "icss-replace-symbols": {
@@ -8043,7 +8053,7 @@
             "integrity": "sha1-g/Cg7DeL8yRheLbCrZE28TWxyWI=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.22"
+                "postcss": "^6.0.1"
             }
         },
         "ieee754": {
@@ -8081,7 +8091,7 @@
             "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -8098,8 +8108,8 @@
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "2.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
@@ -8131,8 +8141,8 @@
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -8152,12 +8162,12 @@
             "integrity": "sha512-RvMOGMXxAqqve4ld128B7TYyNR2aP1LB38dcSpWFmqXrhKPuey1+yFU6kFUgyH8IWX+gRZdWtHN4eQ9d0IpFZg==",
             "dev": true,
             "requires": {
-                "csso": "3.4.0",
-                "htmlparser2": "3.9.2",
-                "is-plain-obj": "1.1.0",
-                "object-assign": "4.1.1",
-                "svgo": "0.7.2",
-                "uglify-js": "3.3.28"
+                "csso": "3.4.x",
+                "htmlparser2": "3.9.x",
+                "is-plain-obj": "1.1.x",
+                "object-assign": "4.1.x",
+                "svgo": "0.7.x",
+                "uglify-js": "3.3.x"
             },
             "dependencies": {
                 "csso": {
@@ -8175,7 +8185,7 @@
                     "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "htmlparser2": {
@@ -8184,12 +8194,12 @@
                     "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0",
-                        "domhandler": "2.4.2",
-                        "domutils": "1.5.1",
-                        "entities": "1.1.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.0.6"
+                        "domelementtype": "^1.3.0",
+                        "domhandler": "^2.3.0",
+                        "domutils": "^1.5.1",
+                        "entities": "^1.1.1",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.2"
                     }
                 }
             }
@@ -8200,8 +8210,8 @@
             "integrity": "sha1-cqsr1hen0FWZBgdE479VFLbu7bA=",
             "dev": true,
             "requires": {
-                "inline-source": "5.2.7",
-                "yargs": "4.8.1"
+                "inline-source": "^5.0.0",
+                "yargs": "^4.1.0"
             }
         },
         "inquirer": {
@@ -8210,20 +8220,20 @@
             "integrity": "sha1-TexvMvN+97sLLtPx0aXD9UUHSRg=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "1.4.0",
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-width": "2.2.0",
-                "external-editor": "1.1.1",
-                "figures": "1.7.0",
-                "lodash": "4.17.10",
+                "ansi-escapes": "^1.1.0",
+                "chalk": "^1.0.0",
+                "cli-cursor": "^1.0.1",
+                "cli-width": "^2.0.0",
+                "external-editor": "^1.1.0",
+                "figures": "^1.3.5",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.6",
-                "pinkie-promise": "2.0.1",
-                "run-async": "2.3.0",
-                "rx": "4.1.0",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "through": "2.3.8"
+                "pinkie-promise": "^2.0.0",
+                "run-async": "^2.2.0",
+                "rx": "^4.1.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.0",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8238,11 +8248,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -8259,7 +8269,7 @@
             "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
             "dev": true,
             "requires": {
-                "meow": "3.7.0"
+                "meow": "^3.3.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -8274,8 +8284,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -8284,8 +8294,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stdin": {
@@ -8300,7 +8310,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -8309,11 +8319,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "map-obj": {
@@ -8328,16 +8338,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     }
                 },
                 "minimist": {
@@ -8352,7 +8362,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -8361,9 +8371,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -8378,9 +8388,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -8389,8 +8399,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "redent": {
@@ -8399,8 +8409,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "strip-bom": {
@@ -8409,7 +8419,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -8418,7 +8428,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "trim-newlines": {
@@ -8440,8 +8450,8 @@
             "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
             "dev": true,
             "requires": {
-                "from2": "2.3.0",
-                "p-is-promise": "1.1.0"
+                "from2": "^2.1.1",
+                "p-is-promise": "^1.1.0"
             }
         },
         "invariant": {
@@ -8450,7 +8460,7 @@
             "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
             "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "invert-kv": {
@@ -8477,8 +8487,8 @@
             "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
             "dev": true,
             "requires": {
-                "is-relative": "0.2.1",
-                "is-windows": "0.2.0"
+                "is-relative": "^0.2.1",
+                "is-windows": "^0.2.0"
             }
         },
         "is-absolute-url": {
@@ -8493,7 +8503,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-arrayish": {
@@ -8508,7 +8518,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -8523,7 +8533,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {
@@ -8538,7 +8548,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-date-object": {
@@ -8553,9 +8563,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -8584,7 +8594,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -8605,7 +8615,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -8614,7 +8624,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -8623,7 +8633,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-number": {
@@ -8632,7 +8642,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -8653,7 +8663,7 @@
             "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
             "dev": true,
             "requires": {
-                "symbol-observable": "0.2.4"
+                "symbol-observable": "^0.2.2"
             },
             "dependencies": {
                 "symbol-observable": {
@@ -8670,7 +8680,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -8693,7 +8703,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -8702,7 +8712,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -8717,7 +8727,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -8752,7 +8762,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1"
+                "has": "^1.0.1"
             }
         },
         "is-relative": {
@@ -8761,7 +8771,7 @@
             "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
             "dev": true,
             "requires": {
-                "is-unc-path": "0.1.2"
+                "is-unc-path": "^0.1.1"
             }
         },
         "is-resolvable": {
@@ -8782,7 +8792,7 @@
             "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
             "dev": true,
             "requires": {
-                "scoped-regex": "1.0.0"
+                "scoped-regex": "^1.0.0"
             }
         },
         "is-ssh": {
@@ -8791,7 +8801,7 @@
             "integrity": "sha1-6+oRaaJhTaOSpjdANmw84EnY3/Y=",
             "dev": true,
             "requires": {
-                "protocols": "1.4.6"
+                "protocols": "^1.1.0"
             }
         },
         "is-stream": {
@@ -8811,7 +8821,7 @@
             "integrity": "sha1-z2EJDaDZ77yrhyLeum8DIgjbsOk=",
             "dev": true,
             "requires": {
-                "html-comment-regex": "1.1.1"
+                "html-comment-regex": "^1.1.0"
             }
         },
         "is-symbol": {
@@ -8826,7 +8836,7 @@
             "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
             "dev": true,
             "requires": {
-                "text-extensions": "1.7.0"
+                "text-extensions": "^1.0.0"
             }
         },
         "is-unc-path": {
@@ -8835,7 +8845,7 @@
             "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.0"
             }
         },
         "is-utf8": {
@@ -8887,8 +8897,8 @@
             "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
             "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
             "requires": {
-                "node-fetch": "1.7.3",
-                "whatwg-fetch": "2.0.4"
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
             }
         },
         "issue-parser": {
@@ -8897,7 +8907,7 @@
             "integrity": "sha512-+dBeNWTdqfC4GX+xJMFmLuzYxY/ve9tUxU1V1INcdq+7c2bbTEojrk14vli1JcGzI0tFCXrF8Ys3hX8J+1NVjw==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.17.4"
             }
         },
         "istextorbinary": {
@@ -8906,9 +8916,9 @@
             "integrity": "sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==",
             "dev": true,
             "requires": {
-                "binaryextensions": "2.1.1",
-                "editions": "1.3.4",
-                "textextensions": "2.2.0"
+                "binaryextensions": "2",
+                "editions": "^1.3.3",
+                "textextensions": "2"
             }
         },
         "isurl": {
@@ -8917,20 +8927,21 @@
             "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
             "dev": true,
             "requires": {
-                "has-to-string-tag-x": "1.4.1",
-                "is-object": "1.0.1"
+                "has-to-string-tag-x": "^1.2.0",
+                "is-object": "^1.0.1"
             }
         },
         "itk": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/itk/-/itk-9.0.0.tgz",
-            "integrity": "sha512-l+P/elWjeqsac8Q6ATmTcnvFdLl2SKEvRKnLeeR8PZlY+4vgvTr6RUPdoianPkvDNIXE3cTSC41JCrtsVrXtVg==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/itk/-/itk-9.1.1.tgz",
+            "integrity": "sha512-y3WjO6YL0TNkoqhwz/0zY6yn9kfua1DhjqyFIxydHlTjK914GLJzo+rTXhbVNyF4gtFLTkGkunY4SN9JdFgbyw==",
             "dev": true,
             "requires": {
-                "commander": "2.15.1",
-                "mime-types": "2.1.18",
-                "promise-file-reader": "0.3.1",
-                "webworker-promise": "0.4.1"
+                "axios": "^0.17.1",
+                "commander": "^2.15.1",
+                "mime-types": "^2.1.15",
+                "promise-file-reader": "^0.3.1",
+                "webworker-promise": "^0.4.1"
             },
             "dependencies": {
                 "commander": {
@@ -8970,8 +8981,8 @@
             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "2.7.3"
+                "argparse": "^1.0.7",
+                "esprima": "^2.6.0"
             }
         },
         "jscodeshift": {
@@ -8980,21 +8991,21 @@
             "integrity": "sha512-JAcQINNMFpdzzpKJN8k5xXjF3XDuckB1/48uScSzcnNyK199iWEc9AxKL9OoX5144M2w5zEx9Qs4/E/eBZZUlw==",
             "dev": true,
             "requires": {
-                "babel-plugin-transform-flow-strip-types": "6.22.0",
-                "babel-preset-es2015": "6.24.1",
-                "babel-preset-stage-1": "6.24.1",
-                "babel-register": "6.26.0",
-                "babylon": "7.0.0-beta.47",
-                "colors": "1.3.0",
-                "flow-parser": "0.73.0",
-                "lodash": "4.17.10",
-                "micromatch": "2.3.11",
-                "neo-async": "2.5.1",
+                "babel-plugin-transform-flow-strip-types": "^6.8.0",
+                "babel-preset-es2015": "^6.9.0",
+                "babel-preset-stage-1": "^6.5.0",
+                "babel-register": "^6.9.0",
+                "babylon": "^7.0.0-beta.30",
+                "colors": "^1.1.2",
+                "flow-parser": "^0.*",
+                "lodash": "^4.13.1",
+                "micromatch": "^2.3.7",
+                "neo-async": "^2.5.0",
                 "node-dir": "0.1.8",
-                "nomnom": "1.8.1",
-                "recast": "0.14.7",
-                "temp": "0.8.3",
-                "write-file-atomic": "1.3.4"
+                "nomnom": "^1.8.1",
+                "recast": "^0.14.1",
+                "temp": "^0.8.1",
+                "write-file-atomic": "^1.2.0"
             },
             "dependencies": {
                 "ast-types": {
@@ -9028,9 +9039,9 @@
                     "dev": true,
                     "requires": {
                         "ast-types": "0.11.3",
-                        "esprima": "4.0.0",
-                        "private": "0.1.8",
-                        "source-map": "0.6.1"
+                        "esprima": "~4.0.0",
+                        "private": "~0.1.5",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -9089,7 +9100,7 @@
             "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonparse": {
@@ -9104,7 +9115,7 @@
             "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
             "dev": true,
             "requires": {
-                "array-includes": "3.0.3"
+                "array-includes": "^3.0.3"
             }
         },
         "jszip": {
@@ -9112,11 +9123,11 @@
             "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
             "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
             "requires": {
-                "core-js": "2.3.0",
-                "es6-promise": "3.0.2",
-                "lie": "3.1.1",
-                "pako": "1.0.6",
-                "readable-stream": "2.0.6"
+                "core-js": "~2.3.0",
+                "es6-promise": "~3.0.2",
+                "lie": "~3.1.0",
+                "pako": "~1.0.2",
+                "readable-stream": "~2.0.6"
             }
         },
         "keyv": {
@@ -9140,7 +9151,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "klaw": {
@@ -9149,7 +9160,7 @@
             "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.9"
             }
         },
         "kw-doc": {
@@ -9169,7 +9180,7 @@
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                     "dev": true,
                     "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                     }
                 },
                 "shelljs": {
@@ -9178,9 +9189,9 @@
                     "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "interpret": "1.1.0",
-                        "rechoir": "0.6.2"
+                        "glob": "^7.0.0",
+                        "interpret": "^1.0.0",
+                        "rechoir": "^0.6.2"
                     }
                 }
             }
@@ -9247,7 +9258,7 @@
                     "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.14.0"
                     }
                 },
                 "commander": {
@@ -9262,9 +9273,9 @@
                     "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "jsonfile": "4.0.0",
-                        "universalify": "0.1.1"
+                        "graceful-fs": "^4.1.2",
+                        "jsonfile": "^4.0.0",
+                        "universalify": "^0.1.0"
                     }
                 },
                 "gh-pages": {
@@ -9274,12 +9285,12 @@
                     "dev": true,
                     "requires": {
                         "async": "2.6.0",
-                        "base64url": "2.0.0",
+                        "base64url": "^2.0.0",
                         "commander": "2.11.0",
-                        "fs-extra": "4.0.3",
-                        "globby": "6.1.0",
+                        "fs-extra": "^4.0.2",
+                        "globby": "^6.1.0",
                         "graceful-fs": "4.1.11",
-                        "rimraf": "2.6.2"
+                        "rimraf": "^2.6.2"
                     }
                 },
                 "globby": {
@@ -9288,11 +9299,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "jsonfile": {
@@ -9301,7 +9312,7 @@
                     "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11"
+                        "graceful-fs": "^4.1.6"
                     }
                 },
                 "pify": {
@@ -9316,9 +9327,9 @@
                     "integrity": "sha512-YA/iYtZpzFe5HyWVGrb02FjPxc4EMCfpoU/Phg9fQoyMC72u9598OUBrsU8IrtwAKG0tO8IYaqbaLIw+k3IRGA==",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "interpret": "1.1.0",
-                        "rechoir": "0.6.2"
+                        "glob": "^7.0.0",
+                        "interpret": "^1.0.0",
+                        "rechoir": "^0.6.2"
                     }
                 }
             }
@@ -9336,7 +9347,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "levn": {
@@ -9345,8 +9356,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "lie": {
@@ -9354,7 +9365,7 @@
             "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
             "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
             "requires": {
-                "immediate": "3.0.6"
+                "immediate": "~3.0.5"
             }
         },
         "listr": {
@@ -9363,23 +9374,23 @@
             "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-truncate": "0.2.1",
-                "figures": "1.7.0",
-                "indent-string": "2.1.0",
-                "is-observable": "0.2.0",
-                "is-promise": "2.1.0",
-                "is-stream": "1.1.0",
-                "listr-silent-renderer": "1.1.1",
-                "listr-update-renderer": "0.4.0",
-                "listr-verbose-renderer": "0.4.1",
-                "log-symbols": "1.0.2",
-                "log-update": "1.0.2",
-                "ora": "0.2.3",
-                "p-map": "1.2.0",
-                "rxjs": "5.5.11",
-                "stream-to-observable": "0.2.0",
-                "strip-ansi": "3.0.1"
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "figures": "^1.7.0",
+                "indent-string": "^2.1.0",
+                "is-observable": "^0.2.0",
+                "is-promise": "^2.1.0",
+                "is-stream": "^1.1.0",
+                "listr-silent-renderer": "^1.1.1",
+                "listr-update-renderer": "^0.4.0",
+                "listr-verbose-renderer": "^0.4.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^1.0.2",
+                "ora": "^0.2.3",
+                "p-map": "^1.1.1",
+                "rxjs": "^5.4.2",
+                "stream-to-observable": "^0.2.0",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9394,11 +9405,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "indent-string": {
@@ -9407,7 +9418,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "log-symbols": {
@@ -9416,7 +9427,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                     }
                 },
                 "supports-color": {
@@ -9439,14 +9450,14 @@
             "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-truncate": "0.2.1",
-                "elegant-spinner": "1.0.1",
-                "figures": "1.7.0",
-                "indent-string": "3.2.0",
-                "log-symbols": "1.0.2",
-                "log-update": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "elegant-spinner": "^1.0.1",
+                "figures": "^1.7.0",
+                "indent-string": "^3.0.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^1.0.2",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9461,11 +9472,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "log-symbols": {
@@ -9474,7 +9485,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                     }
                 },
                 "supports-color": {
@@ -9491,10 +9502,10 @@
             "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "date-fns": "1.29.0",
-                "figures": "1.7.0"
+                "chalk": "^1.1.3",
+                "cli-cursor": "^1.0.2",
+                "date-fns": "^1.27.2",
+                "figures": "^1.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9509,11 +9520,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -9530,10 +9541,10 @@
             "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "2.2.0",
-                "pify": "2.3.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^2.2.0",
+                "pify": "^2.0.0",
+                "strip-bom": "^3.0.0"
             },
             "dependencies": {
                 "pify": {
@@ -9550,7 +9561,7 @@
             "integrity": "sha1-VuC/CL2XCLJqdltoUJhAyN7J/bw=",
             "dev": true,
             "requires": {
-                "find-cache-dir": "0.1.1",
+                "find-cache-dir": "^0.1.1",
                 "mkdirp": "0.5.1"
             },
             "dependencies": {
@@ -9560,9 +9571,9 @@
                     "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
                     "dev": true,
                     "requires": {
-                        "commondir": "1.0.1",
-                        "mkdirp": "0.5.1",
-                        "pkg-dir": "1.0.0"
+                        "commondir": "^1.0.1",
+                        "mkdirp": "^0.5.1",
+                        "pkg-dir": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -9571,8 +9582,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-exists": {
@@ -9581,7 +9592,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pkg-dir": {
@@ -9590,7 +9601,7 @@
                     "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2"
+                        "find-up": "^1.0.0"
                     }
                 }
             }
@@ -9607,9 +9618,9 @@
             "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
             "dev": true,
             "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1"
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0"
             }
         },
         "locate-path": {
@@ -9618,8 +9629,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -9676,9 +9687,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.map": {
@@ -9699,8 +9710,8 @@
             "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.templatesettings": "4.1.0"
+                "lodash._reinterpolate": "~3.0.0",
+                "lodash.templatesettings": "^4.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -9709,7 +9720,7 @@
             "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0"
+                "lodash._reinterpolate": "~3.0.0"
             }
         },
         "lodash.toarray": {
@@ -9730,7 +9741,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "log-update": {
@@ -9739,8 +9750,8 @@
             "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "1.4.0",
-                "cli-cursor": "1.0.2"
+                "ansi-escapes": "^1.0.0",
+                "cli-cursor": "^1.0.2"
             }
         },
         "loglevel": {
@@ -9755,8 +9766,8 @@
             "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
             "dev": true,
             "requires": {
-                "es6-symbol": "3.1.1",
-                "object.assign": "4.1.0"
+                "es6-symbol": "^3.1.1",
+                "object.assign": "^4.1.0"
             }
         },
         "longest": {
@@ -9770,7 +9781,7 @@
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
             "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
             "requires": {
-                "js-tokens": "3.0.2"
+                "js-tokens": "^3.0.0"
             }
         },
         "loud-rejection": {
@@ -9779,8 +9790,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lower-case": {
@@ -9801,8 +9812,8 @@
             "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "make-dir": {
@@ -9811,7 +9822,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "map-cache": {
@@ -9832,7 +9843,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "marked": {
@@ -9847,11 +9858,11 @@
             "integrity": "sha1-Xq9Wi+ZvaGVBr6UqVYKAMQox3i0=",
             "dev": true,
             "requires": {
-                "cardinal": "1.0.0",
-                "chalk": "1.1.3",
-                "cli-table": "0.3.1",
-                "lodash.assign": "4.2.0",
-                "node-emoji": "1.8.1"
+                "cardinal": "^1.0.0",
+                "chalk": "^1.1.3",
+                "cli-table": "^0.3.1",
+                "lodash.assign": "^4.2.0",
+                "node-emoji": "^1.4.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9866,11 +9877,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -9899,8 +9910,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "mdn-data": {
@@ -9921,7 +9932,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "mem-fs": {
@@ -9930,9 +9941,9 @@
             "integrity": "sha1-uK6NLj/Lb10/kWXBLUVRoGXZicw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "1.2.0",
-                "vinyl-file": "2.0.0"
+                "through2": "^2.0.0",
+                "vinyl": "^1.1.0",
+                "vinyl-file": "^2.0.0"
             }
         },
         "mem-fs-editor": {
@@ -9941,17 +9952,17 @@
             "integrity": "sha512-QHvdXLLNmwJXxKdf7x27aNUren6IoPxwcM8Sfd+S6/ddQQMcYdEtVKsh6ilpqMrU18VQuKZEaH0aCGt3JDbA0g==",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "deep-extend": "0.5.1",
-                "ejs": "2.6.1",
-                "glob": "7.1.2",
-                "globby": "8.0.1",
-                "isbinaryfile": "3.0.2",
-                "mkdirp": "0.5.1",
-                "multimatch": "2.1.0",
-                "rimraf": "2.6.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0"
+                "commondir": "^1.0.1",
+                "deep-extend": "^0.5.1",
+                "ejs": "^2.5.9",
+                "glob": "^7.0.3",
+                "globby": "^8.0.0",
+                "isbinaryfile": "^3.0.2",
+                "mkdirp": "^0.5.0",
+                "multimatch": "^2.0.0",
+                "rimraf": "^2.2.8",
+                "through2": "^2.0.0",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
@@ -9978,13 +9989,13 @@
                     "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "dir-glob": "2.0.0",
-                        "fast-glob": "2.2.2",
-                        "glob": "7.1.2",
-                        "ignore": "3.3.8",
-                        "pify": "3.0.0",
-                        "slash": "1.0.0"
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "fast-glob": "^2.0.2",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "replace-ext": {
@@ -9999,12 +10010,12 @@
                     "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -10021,15 +10032,15 @@
             "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
             "dev": true,
             "requires": {
-                "camelcase-keys": "4.2.0",
-                "decamelize-keys": "1.1.0",
-                "loud-rejection": "1.6.0",
-                "minimist": "1.2.0",
-                "minimist-options": "3.0.2",
-                "normalize-package-data": "2.4.0",
-                "read-pkg-up": "3.0.0",
-                "redent": "2.0.0",
-                "trim-newlines": "2.0.0"
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist": "^1.1.3",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0"
             },
             "dependencies": {
                 "load-json-file": {
@@ -10038,10 +10049,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "minimist": {
@@ -10056,8 +10067,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "read-pkg": {
@@ -10066,9 +10077,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -10077,8 +10088,8 @@
                     "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 }
             }
@@ -10101,7 +10112,7 @@
             "integrity": "sha1-y+BPWUppheryf3+PCyo6z2+dVi0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.1.0"
             }
         },
         "merge2": {
@@ -10122,19 +10133,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "is-extglob": {
@@ -10149,7 +10160,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -10160,8 +10171,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -10182,7 +10193,7 @@
             "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.33.0"
             }
         },
         "mimic-fn": {
@@ -10214,7 +10225,7 @@
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -10229,8 +10240,8 @@
             "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "is-plain-obj": "1.1.0"
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0"
             }
         },
         "mississippi": {
@@ -10239,16 +10250,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "duplexify": "3.6.0",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.3",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.5.1",
-                "stream-each": "1.2.2",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
             }
         },
         "mitt": {
@@ -10263,8 +10274,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -10273,7 +10284,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -10323,7 +10334,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -10339,7 +10350,7 @@
             "resolved": "https://registry.npmjs.org/monologue.js/-/monologue.js-0.3.5.tgz",
             "integrity": "sha1-IM5RQ9ZegqOh91rakUfFJIeRSWk=",
             "requires": {
-                "lodash": "3.10.1",
+                "lodash": "3.x",
                 "riveter": "0.2.0"
             },
             "dependencies": {
@@ -10361,12 +10372,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "copy-concurrently": "1.0.5",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
             }
         },
         "ms": {
@@ -10381,8 +10392,8 @@
             "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
             "dev": true,
             "requires": {
-                "dns-packet": "1.3.1",
-                "thunky": "1.0.2"
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
             }
         },
         "multicast-dns-service-types": {
@@ -10397,10 +10408,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
         "mute-stream": {
@@ -10422,18 +10433,18 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -10504,7 +10515,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-dir": {
@@ -10519,7 +10530,7 @@
             "integrity": "sha512-+ktMAh1Jwas+TnGodfCfjUbJKoANqPaJFN0z0iqh41eqD8dvguNzcitVSBSVK1pidz0AqGbLKcoVuVLRVZ/aVg==",
             "dev": true,
             "requires": {
-                "lodash.toarray": "4.4.0"
+                "lodash.toarray": "^4.4.0"
             }
         },
         "node-fetch": {
@@ -10527,8 +10538,8 @@
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
             "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
             "requires": {
-                "encoding": "0.1.12",
-                "is-stream": "1.1.0"
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
             }
         },
         "node-forge": {
@@ -10543,28 +10554,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.6",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.2",
-                "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.10",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.3",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -10580,13 +10591,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -10595,7 +10606,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -10606,8 +10617,8 @@
             "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
             "dev": true,
             "requires": {
-                "chalk": "0.4.0",
-                "underscore": "1.6.0"
+                "chalk": "~0.4.0",
+                "underscore": "~1.6.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10622,9 +10633,9 @@
                     "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "1.0.0",
-                        "has-color": "0.1.7",
-                        "strip-ansi": "0.1.1"
+                        "ansi-styles": "~1.0.0",
+                        "has-color": "~0.1.0",
+                        "strip-ansi": "~0.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -10641,10 +10652,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.6.0",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.3"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -10653,7 +10664,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -10668,10 +10679,10 @@
             "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "prepend-http": "1.0.4",
-                "query-string": "4.3.4",
-                "sort-keys": "1.1.2"
+                "object-assign": "^4.0.1",
+                "prepend-http": "^1.0.0",
+                "query-string": "^4.1.0",
+                "sort-keys": "^1.0.0"
             }
         },
         "normalize.css": {
@@ -10690,7 +10701,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "nth-check": {
@@ -10699,7 +10710,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "num2fraction": {
@@ -10725,9 +10736,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -10736,7 +10747,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -10759,7 +10770,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -10776,10 +10787,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.11"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.getownpropertydescriptors": {
@@ -10788,8 +10799,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
             }
         },
         "object.omit": {
@@ -10798,8 +10809,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -10808,7 +10819,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -10845,7 +10856,7 @@
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -10866,7 +10877,7 @@
             "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
             "dev": true,
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {
@@ -10875,8 +10886,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.8",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             }
         },
         "optionator": {
@@ -10885,12 +10896,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             },
             "dependencies": {
                 "wordwrap": {
@@ -10907,10 +10918,10 @@
             "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-spinners": "0.1.2",
-                "object-assign": "4.1.1"
+                "chalk": "^1.1.1",
+                "cli-cursor": "^1.0.2",
+                "cli-spinners": "^0.1.2",
+                "object-assign": "^4.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -10925,11 +10936,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -10946,7 +10957,7 @@
             "integrity": "sha512-IEvtB5vM5ULvwnqMxWBLxkS13JIEXbakizMSo3yoPNPCIWzg8TG3Usn/UhXoZFM/m+FuEA20KdzPSFq/0rS+UA==",
             "dev": true,
             "requires": {
-                "url-parse": "1.4.0"
+                "url-parse": "~1.4.0"
             }
         },
         "os-browserify": {
@@ -10967,7 +10978,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-shim": {
@@ -10994,7 +11005,7 @@
             "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
             "dev": true,
             "requires": {
-                "p-reduce": "1.0.0"
+                "p-reduce": "^1.0.0"
             }
         },
         "p-filter": {
@@ -11003,7 +11014,7 @@
             "integrity": "sha1-Yp0xcVAgnI/VCLoTdxPvS7kg6ds=",
             "dev": true,
             "requires": {
-                "p-map": "1.2.0"
+                "p-map": "^1.0.0"
             }
         },
         "p-finally": {
@@ -11030,7 +11041,7 @@
             "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -11039,7 +11050,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.2.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-map": {
@@ -11060,7 +11071,7 @@
             "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
             "dev": true,
             "requires": {
-                "retry": "0.12.0"
+                "retry": "^0.12.0"
             }
         },
         "p-timeout": {
@@ -11069,7 +11080,7 @@
             "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
             "dev": true,
             "requires": {
-                "p-finally": "1.0.0"
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -11084,7 +11095,7 @@
             "integrity": "sha1-b7ySQEXSRPKiokRQMGDTv8YAl3Q=",
             "dev": true,
             "requires": {
-                "repeat-string": "1.6.1"
+                "repeat-string": "^1.5.2"
             }
         },
         "pako": {
@@ -11098,9 +11109,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -11115,13 +11126,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -11130,7 +11141,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -11141,7 +11152,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "paraview-glance": {
@@ -11153,9 +11164,9 @@
                 "font-awesome": "4.5.0",
                 "monologue.js": "0.3.5",
                 "mout": "1.0.0",
-                "normalize.css": "8.0.0",
+                "normalize.css": "^8.0.0",
                 "paraviewweb": "3.0.13",
-                "react-toastify": "4.0.1",
+                "react-toastify": "^4.0.0-rc.5",
                 "shelljs": "0.7.8",
                 "vtk.js": "6.4.19"
             }
@@ -11178,11 +11189,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.2.0",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.16"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-domain": {
@@ -11191,11 +11202,11 @@
             "integrity": "sha512-xOQ/B+pnS8uzqFMHcS7VS9J7Cn+rFyPlGIoDMFL2e5g/tPhlpa8MSHQmFAlABHBKPCXgOOxFt5PFNdEmwtwvqQ==",
             "dev": true,
             "requires": {
-                "chai": "4.1.2",
-                "fs-copy-file-sync": "1.1.1",
-                "got": "8.3.1",
-                "mkdirp": "0.5.1",
-                "mocha": "4.1.0"
+                "chai": "^4.1.2",
+                "fs-copy-file-sync": "^1.1.1",
+                "got": "^8.0.1",
+                "mkdirp": "^0.5.1",
+                "mocha": "^4.0.1"
             }
         },
         "parse-github-url": {
@@ -11210,10 +11221,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -11228,7 +11239,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -11239,7 +11250,7 @@
             "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.1"
+                "error-ex": "^1.2.0"
             }
         },
         "parse-passwd": {
@@ -11254,8 +11265,8 @@
             "integrity": "sha1-V8FUKKuKiSsfQ4aWRccR0OFEtVQ=",
             "dev": true,
             "requires": {
-                "is-ssh": "1.3.0",
-                "protocols": "1.4.6"
+                "is-ssh": "^1.3.0",
+                "protocols": "^1.4.0"
             }
         },
         "parseurl": {
@@ -11322,7 +11333,7 @@
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pathval": {
@@ -11337,11 +11348,11 @@
             "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "pify": {
@@ -11362,7 +11373,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -11371,7 +11382,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "pluralize": {
@@ -11386,9 +11397,9 @@
             "integrity": "sha1-uzLs2HwnEErm7kS1o8y/Drsa7ek=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             },
             "dependencies": {
                 "debug": {
@@ -11414,9 +11425,9 @@
             "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "source-map": "0.6.1",
-                "supports-color": "5.4.0"
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
             }
         },
         "postcss-calc": {
@@ -11425,9 +11436,9 @@
             "integrity": "sha1-d7rnypKK2FcW4v2kLyYb98HWW14=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-message-helpers": "2.0.0",
-                "reduce-css-calc": "1.3.0"
+                "postcss": "^5.0.2",
+                "postcss-message-helpers": "^2.0.0",
+                "reduce-css-calc": "^1.2.6"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11442,11 +11453,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11469,10 +11480,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11487,7 +11498,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11498,9 +11509,9 @@
             "integrity": "sha1-ZjFBfV8OkJo9fsJrJMio0eT5bks=",
             "dev": true,
             "requires": {
-                "colormin": "1.1.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "colormin": "^1.0.5",
+                "postcss": "^5.0.13",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11515,11 +11526,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11542,10 +11553,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11560,7 +11571,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11571,8 +11582,8 @@
             "integrity": "sha1-u9hZPFwf0uPRwyK7kl3K6Nrk1i0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.11",
+                "postcss-value-parser": "^3.1.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11587,11 +11598,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11614,10 +11625,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11632,7 +11643,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11643,7 +11654,7 @@
             "integrity": "sha1-vv6J+v1bPazlzM5Rt2uBUUvgDj0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11658,11 +11669,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11685,10 +11696,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11703,7 +11714,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11714,7 +11725,7 @@
             "integrity": "sha1-uavye4isGIFYpesSq8riAmO5GTI=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11729,11 +11740,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11756,10 +11767,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11774,7 +11785,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11785,7 +11796,7 @@
             "integrity": "sha1-0rS9nVztXr2Nyt52QMfXzX9PkrU=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.14"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11800,11 +11811,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11827,10 +11838,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11845,7 +11856,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11856,7 +11867,7 @@
             "integrity": "sha1-ix6vVU9ob7KIzYdMVWZ7CqNmjVg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11871,11 +11882,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11898,10 +11909,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11916,7 +11927,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11927,8 +11938,8 @@
             "integrity": "sha1-vOMLLMWR/8Y0Mitfs0ZLbZNPRDM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "postcss": "^5.0.14",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -11943,11 +11954,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -11970,10 +11981,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -11988,7 +11999,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -11999,7 +12010,7 @@
             "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12014,11 +12025,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12041,10 +12052,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12059,7 +12070,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12070,10 +12081,10 @@
             "integrity": "sha1-U56a/J3chiASHr+djDZz4M5Q0oo=",
             "dev": true,
             "requires": {
-                "cosmiconfig": "2.2.2",
-                "object-assign": "4.1.1",
-                "postcss-load-options": "1.2.0",
-                "postcss-load-plugins": "2.3.0"
+                "cosmiconfig": "^2.1.0",
+                "object-assign": "^4.1.0",
+                "postcss-load-options": "^1.2.0",
+                "postcss-load-plugins": "^2.3.0"
             }
         },
         "postcss-load-options": {
@@ -12082,8 +12093,8 @@
             "integrity": "sha1-sJixVZ3awt8EvAuzdfmaXP4rbYw=",
             "dev": true,
             "requires": {
-                "cosmiconfig": "2.2.2",
-                "object-assign": "4.1.1"
+                "cosmiconfig": "^2.1.0",
+                "object-assign": "^4.1.0"
             }
         },
         "postcss-load-plugins": {
@@ -12092,8 +12103,8 @@
             "integrity": "sha1-dFdoEWWZrKLwCfrUJrABdQSdjZI=",
             "dev": true,
             "requires": {
-                "cosmiconfig": "2.2.2",
-                "object-assign": "4.1.1"
+                "cosmiconfig": "^2.1.1",
+                "object-assign": "^4.1.0"
             }
         },
         "postcss-loader": {
@@ -12102,10 +12113,10 @@
             "integrity": "sha512-RuBcNE8rjCkIB0IsbmkGFRmQJTeQJfCI88E0VTarPNTvaNSv9OFv1DvTwgtAN/qlzyiELsmmmtX/tEzKp/cdug==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "postcss": "6.0.22",
-                "postcss-load-config": "1.2.0",
-                "schema-utils": "0.4.5"
+                "loader-utils": "^1.1.0",
+                "postcss": "^6.0.0",
+                "postcss-load-config": "^1.2.0",
+                "schema-utils": "^0.4.0"
             }
         },
         "postcss-merge-idents": {
@@ -12114,9 +12125,9 @@
             "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.10",
+                "postcss-value-parser": "^3.1.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12131,11 +12142,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12158,10 +12169,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12176,7 +12187,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12187,7 +12198,7 @@
             "integrity": "sha1-I9kM0Sewp3mUkVMyc5A0oaTz1lg=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12202,11 +12213,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12229,10 +12240,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12247,7 +12258,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12258,11 +12269,11 @@
             "integrity": "sha1-0d9d+qexrMO+VT8OnhDofGG19yE=",
             "dev": true,
             "requires": {
-                "browserslist": "1.7.7",
-                "caniuse-api": "1.6.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.2"
+                "browserslist": "^1.5.2",
+                "caniuse-api": "^1.5.2",
+                "postcss": "^5.0.4",
+                "postcss-selector-parser": "^2.2.2",
+                "vendors": "^1.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12277,8 +12288,8 @@
                     "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
                     "dev": true,
                     "requires": {
-                        "caniuse-db": "1.0.30000847",
-                        "electron-to-chromium": "1.3.48"
+                        "caniuse-db": "^1.0.30000639",
+                        "electron-to-chromium": "^1.2.7"
                     }
                 },
                 "chalk": {
@@ -12287,11 +12298,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12314,10 +12325,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12332,7 +12343,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12349,9 +12360,9 @@
             "integrity": "sha1-S1jttWZB66fIR0qzUmyv17vey2k=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "object-assign": "^4.0.1",
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12366,11 +12377,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12393,10 +12404,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12411,7 +12422,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12422,8 +12433,8 @@
             "integrity": "sha1-Xb2hE3NwP4PPtKPqOIHY11/15uE=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.12",
+                "postcss-value-parser": "^3.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12438,11 +12449,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12465,10 +12476,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12483,7 +12494,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12494,10 +12505,10 @@
             "integrity": "sha1-rSzgcTc7lDs9kwo/pZo1jCjW8fM=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.2",
+                "postcss-value-parser": "^3.0.2",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12512,11 +12523,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12539,10 +12550,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12557,7 +12568,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12568,10 +12579,10 @@
             "integrity": "sha1-ssapjAByz5G5MtGkllCBFDEXNb8=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-selector-parser": "2.2.3"
+                "alphanum-sort": "^1.0.2",
+                "has": "^1.0.1",
+                "postcss": "^5.0.14",
+                "postcss-selector-parser": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12586,11 +12597,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12613,10 +12624,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12631,7 +12642,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12642,7 +12653,7 @@
             "integrity": "sha1-ZhQOzs447wa/DT41XWm/WdFB6oU=",
             "dev": true,
             "requires": {
-                "postcss": "6.0.22"
+                "postcss": "^6.0.1"
             }
         },
         "postcss-modules-local-by-default": {
@@ -12651,8 +12662,8 @@
             "integrity": "sha1-99gMOYxaOT+nlkRmvRlQCn1hwGk=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.22"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             }
         },
         "postcss-modules-scope": {
@@ -12661,8 +12672,8 @@
             "integrity": "sha1-1upkmUx5+XtipytCb75gVqGUu5A=",
             "dev": true,
             "requires": {
-                "css-selector-tokenizer": "0.7.0",
-                "postcss": "6.0.22"
+                "css-selector-tokenizer": "^0.7.0",
+                "postcss": "^6.0.1"
             }
         },
         "postcss-modules-values": {
@@ -12671,8 +12682,8 @@
             "integrity": "sha1-7P+p1+GSUYOJ9CrQ6D9yrsRW6iA=",
             "dev": true,
             "requires": {
-                "icss-replace-symbols": "1.1.0",
-                "postcss": "6.0.22"
+                "icss-replace-symbols": "^1.1.0",
+                "postcss": "^6.0.1"
             }
         },
         "postcss-normalize-charset": {
@@ -12681,7 +12692,7 @@
             "integrity": "sha1-757nEhLX/nWceO0WL2HtYrXLk/E=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.5"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12696,11 +12707,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12723,10 +12734,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12741,7 +12752,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12752,10 +12763,10 @@
             "integrity": "sha1-EI90s/L82viRov+j6kWSJ5/HgiI=",
             "dev": true,
             "requires": {
-                "is-absolute-url": "2.1.0",
-                "normalize-url": "1.9.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "is-absolute-url": "^2.0.0",
+                "normalize-url": "^1.4.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12770,11 +12781,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12797,10 +12808,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12815,7 +12826,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12826,8 +12837,8 @@
             "integrity": "sha1-7sbCpntsQSqNsgQud/6NpD+VwR0=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12842,11 +12853,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12869,10 +12880,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12887,7 +12898,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12898,7 +12909,7 @@
             "integrity": "sha1-tJWUnWOcYxRxRWSDJoUyFvPBCQA=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.8"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12913,11 +12924,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -12940,10 +12951,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -12958,7 +12969,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -12969,8 +12980,8 @@
             "integrity": "sha1-wsbSDMlYKE9qv75j92Cb9AkFmtM=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "postcss": "^5.0.4",
+                "postcss-value-parser": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12985,11 +12996,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -13012,10 +13023,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -13030,7 +13041,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -13041,7 +13052,7 @@
             "integrity": "sha1-aPgGlfBF0IJjqHmtJA343WT2ROo=",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.0.4"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13056,11 +13067,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -13083,10 +13094,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -13101,7 +13112,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -13112,9 +13123,9 @@
             "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.8",
+                "postcss-value-parser": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13129,11 +13140,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -13156,10 +13167,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -13174,7 +13185,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -13185,9 +13196,9 @@
             "integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
             "dev": true,
             "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postcss-svgo": {
@@ -13196,10 +13207,10 @@
             "integrity": "sha1-tt8YqmE7Zm4TPwittSGcJoSsEI0=",
             "dev": true,
             "requires": {
-                "is-svg": "2.1.0",
-                "postcss": "5.2.18",
-                "postcss-value-parser": "3.3.0",
-                "svgo": "0.7.2"
+                "is-svg": "^2.0.0",
+                "postcss": "^5.0.14",
+                "postcss-value-parser": "^3.2.3",
+                "svgo": "^0.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13214,11 +13225,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -13241,10 +13252,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -13259,7 +13270,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -13270,9 +13281,9 @@
             "integrity": "sha1-mB1X0p3csz57Hf4f1DuGSfkzyh0=",
             "dev": true,
             "requires": {
-                "alphanum-sort": "1.0.2",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "alphanum-sort": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13287,11 +13298,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -13314,10 +13325,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -13332,7 +13343,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -13349,7 +13360,7 @@
             "integrity": "sha512-a9b2ZXoy60xl28m+jedXYvbXLdYSLPXOqvgkLUHhOUbhIRlVoSHRGhGtpMLkcgVc05lu3JUBEypLVcTYNcltMw==",
             "dev": true,
             "requires": {
-                "postcss": "6.0.9"
+                "postcss": "^6.0.9"
             },
             "dependencies": {
                 "abbrev": {
@@ -13362,9 +13373,9 @@
                     "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                     "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                     "requires": {
-                        "kind-of": "3.2.2",
-                        "longest": "1.0.1",
-                        "repeat-string": "1.6.1"
+                        "kind-of": "^3.0.2",
+                        "longest": "^1.0.1",
+                        "repeat-string": "^1.5.2"
                     }
                 },
                 "amdefine": {
@@ -13378,7 +13389,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.0"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "argparse": {
@@ -13386,7 +13397,7 @@
                     "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                     "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                     "requires": {
-                        "sprintf-js": "1.0.3"
+                        "sprintf-js": "~1.0.2"
                     }
                 },
                 "assertion-error": {
@@ -13409,7 +13420,7 @@
                     "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
                     "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -13430,8 +13441,8 @@
                     "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                     "optional": true,
                     "requires": {
-                        "align-text": "0.1.4",
-                        "lazy-cache": "1.0.4"
+                        "align-text": "^0.1.3",
+                        "lazy-cache": "^1.0.3"
                     }
                 },
                 "chai": {
@@ -13439,12 +13450,12 @@
                     "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
                     "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
                     "requires": {
-                        "assertion-error": "1.0.2",
-                        "check-error": "1.0.2",
-                        "deep-eql": "2.0.2",
-                        "get-func-name": "2.0.0",
-                        "pathval": "1.1.0",
-                        "type-detect": "4.0.3"
+                        "assertion-error": "^1.0.1",
+                        "check-error": "^1.0.1",
+                        "deep-eql": "^2.0.1",
+                        "get-func-name": "^2.0.0",
+                        "pathval": "^1.0.0",
+                        "type-detect": "^4.0.0"
                     }
                 },
                 "chalk": {
@@ -13453,9 +13464,9 @@
                     "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.2.1"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "check-error": {
@@ -13469,8 +13480,8 @@
                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                     "optional": true,
                     "requires": {
-                        "center-align": "0.1.3",
-                        "right-align": "0.1.3",
+                        "center-align": "^0.1.1",
+                        "right-align": "^0.1.1",
                         "wordwrap": "0.0.2"
                     },
                     "dependencies": {
@@ -13488,7 +13499,7 @@
                     "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                     "dev": true,
                     "requires": {
-                        "color-name": "1.1.3"
+                        "color-name": "^1.1.1"
                     }
                 },
                 "color-name": {
@@ -13502,7 +13513,7 @@
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                     "requires": {
-                        "graceful-readlink": "1.0.1"
+                        "graceful-readlink": ">= 1.0.0"
                     }
                 },
                 "concat-map": {
@@ -13529,7 +13540,7 @@
                     "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
                     "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
                     "requires": {
-                        "type-detect": "3.0.0"
+                        "type-detect": "^3.0.0"
                     },
                     "dependencies": {
                         "type-detect": {
@@ -13559,11 +13570,11 @@
                     "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
                     "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
                     "requires": {
-                        "esprima": "2.7.3",
-                        "estraverse": "1.9.3",
-                        "esutils": "2.0.2",
-                        "optionator": "0.8.2",
-                        "source-map": "0.2.0"
+                        "esprima": "^2.7.1",
+                        "estraverse": "^1.9.1",
+                        "esutils": "^2.0.2",
+                        "optionator": "^0.8.1",
+                        "source-map": "~0.2.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -13572,7 +13583,7 @@
                             "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                             "optional": true,
                             "requires": {
-                                "amdefine": "1.0.1"
+                                "amdefine": ">=0.0.4"
                             }
                         }
                     }
@@ -13612,11 +13623,11 @@
                     "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "graceful-readlink": {
@@ -13634,10 +13645,10 @@
                     "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
                     "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
                     "requires": {
-                        "async": "1.5.2",
-                        "optimist": "0.6.1",
-                        "source-map": "0.4.4",
-                        "uglify-js": "2.8.29"
+                        "async": "^1.4.0",
+                        "optimist": "^0.6.1",
+                        "source-map": "^0.4.4",
+                        "uglify-js": "^2.6"
                     },
                     "dependencies": {
                         "source-map": {
@@ -13645,7 +13656,7 @@
                             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                             "requires": {
-                                "amdefine": "1.0.1"
+                                "amdefine": ">=0.0.4"
                             }
                         }
                     }
@@ -13661,8 +13672,8 @@
                     "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -13685,20 +13696,20 @@
                     "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
                     "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
                     "requires": {
-                        "abbrev": "1.0.9",
-                        "async": "1.5.2",
-                        "escodegen": "1.8.1",
-                        "esprima": "2.7.3",
-                        "glob": "5.0.15",
-                        "handlebars": "4.0.10",
-                        "js-yaml": "3.9.1",
-                        "mkdirp": "0.5.1",
-                        "nopt": "3.0.6",
-                        "once": "1.4.0",
-                        "resolve": "1.1.7",
-                        "supports-color": "3.2.3",
-                        "which": "1.3.0",
-                        "wordwrap": "1.0.0"
+                        "abbrev": "1.0.x",
+                        "async": "1.x",
+                        "escodegen": "1.8.x",
+                        "esprima": "2.7.x",
+                        "glob": "^5.0.15",
+                        "handlebars": "^4.0.1",
+                        "js-yaml": "3.x",
+                        "mkdirp": "0.5.x",
+                        "nopt": "3.x",
+                        "once": "1.x",
+                        "resolve": "1.1.x",
+                        "supports-color": "^3.1.0",
+                        "which": "^1.1.1",
+                        "wordwrap": "^1.0.0"
                     },
                     "dependencies": {
                         "has-flag": {
@@ -13711,7 +13722,7 @@
                             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                             "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                             "requires": {
-                                "has-flag": "1.0.0"
+                                "has-flag": "^1.0.0"
                             }
                         }
                     }
@@ -13721,8 +13732,8 @@
                     "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
                     "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
                     "requires": {
-                        "argparse": "1.0.9",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     },
                     "dependencies": {
                         "esprima": {
@@ -13742,7 +13753,7 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "requires": {
-                        "is-buffer": "1.1.5"
+                        "is-buffer": "^1.1.5"
                     }
                 },
                 "lazy-cache": {
@@ -13756,8 +13767,8 @@
                     "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                     "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                     "requires": {
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2"
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2"
                     }
                 },
                 "lodash._baseassign": {
@@ -13765,8 +13776,8 @@
                     "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                     "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
                     "requires": {
-                        "lodash._basecopy": "3.0.1",
-                        "lodash.keys": "3.1.2"
+                        "lodash._basecopy": "^3.0.0",
+                        "lodash.keys": "^3.0.0"
                     }
                 },
                 "lodash._basecopy": {
@@ -13794,9 +13805,9 @@
                     "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
                     "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
                     "requires": {
-                        "lodash._baseassign": "3.2.0",
-                        "lodash._basecreate": "3.0.3",
-                        "lodash._isiterateecall": "3.0.9"
+                        "lodash._baseassign": "^3.0.0",
+                        "lodash._basecreate": "^3.0.0",
+                        "lodash._isiterateecall": "^3.0.0"
                     }
                 },
                 "lodash.isarguments": {
@@ -13814,9 +13825,9 @@
                     "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                     "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                     "requires": {
-                        "lodash._getnative": "3.9.1",
-                        "lodash.isarguments": "3.1.0",
-                        "lodash.isarray": "3.0.4"
+                        "lodash._getnative": "^3.0.0",
+                        "lodash.isarguments": "^3.0.0",
+                        "lodash.isarray": "^3.0.0"
                     }
                 },
                 "longest": {
@@ -13829,7 +13840,7 @@
                     "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -13875,12 +13886,12 @@
                             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                             "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                             "requires": {
-                                "fs.realpath": "1.0.0",
-                                "inflight": "1.0.6",
-                                "inherits": "2.0.3",
-                                "minimatch": "3.0.4",
-                                "once": "1.4.0",
-                                "path-is-absolute": "1.0.1"
+                                "fs.realpath": "^1.0.0",
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "^3.0.2",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         },
                         "has-flag": {
@@ -13893,7 +13904,7 @@
                             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                             "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                             "requires": {
-                                "has-flag": "1.0.0"
+                                "has-flag": "^1.0.0"
                             }
                         }
                     }
@@ -13908,7 +13919,7 @@
                     "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                     "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                     "requires": {
-                        "abbrev": "1.0.9"
+                        "abbrev": "1"
                     }
                 },
                 "once": {
@@ -13916,7 +13927,7 @@
                     "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "optimist": {
@@ -13924,8 +13935,8 @@
                     "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                     "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                     "requires": {
-                        "minimist": "0.0.10",
-                        "wordwrap": "0.0.3"
+                        "minimist": "~0.0.1",
+                        "wordwrap": "~0.0.2"
                     },
                     "dependencies": {
                         "wordwrap": {
@@ -13940,12 +13951,12 @@
                     "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
                     "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
                     "requires": {
-                        "deep-is": "0.1.3",
-                        "fast-levenshtein": "2.0.6",
-                        "levn": "0.3.0",
-                        "prelude-ls": "1.1.2",
-                        "type-check": "0.3.2",
-                        "wordwrap": "1.0.0"
+                        "deep-is": "~0.1.3",
+                        "fast-levenshtein": "~2.0.4",
+                        "levn": "~0.3.0",
+                        "prelude-ls": "~1.1.2",
+                        "type-check": "~0.3.2",
+                        "wordwrap": "~1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -13964,9 +13975,9 @@
                     "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.1.0",
-                        "source-map": "0.5.6",
-                        "supports-color": "4.2.1"
+                        "chalk": "^2.1.0",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^4.2.1"
                     }
                 },
                 "postcss-js-mixins": {
@@ -13974,25 +13985,28 @@
                     "resolved": "https://registry.npmjs.org/postcss-js-mixins/-/postcss-js-mixins-2.5.2.tgz",
                     "integrity": "sha512-DpUP10V5TowIN1H/pgRHVlofa32FUvgVkosYcrqY97vqClz70ndw7iYdlcXdYOrJEMcyI96YDpw0/EEGO18coA==",
                     "requires": {
-                        "postcss": "6.0.9",
-                        "tinycolor2": "1.4.1"
+                        "postcss": "^6.0.9",
+                        "tinycolor2": "^1.4.1"
                     },
                     "dependencies": {
                         "abbrev": {
-                            "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                            "version": "1.0.9",
+                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
                             "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
                         },
                         "align-text": {
-                            "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                             "requires": {
-                                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
                             }
                         },
                         "amdefine": {
-                            "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
                             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
                         },
                         "ansi-styles": {
@@ -14000,14 +14014,15 @@
                             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                             "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                             "requires": {
-                                "color-convert": "1.9.0"
+                                "color-convert": "^1.9.0"
                             }
                         },
                         "argparse": {
-                            "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                            "version": "1.0.9",
+                            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                             "requires": {
-                                "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                                "sprintf-js": "~1.0.2"
                             }
                         },
                         "assertion-error": {
@@ -14016,19 +14031,22 @@
                             "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
                         },
                         "async": {
-                            "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                            "version": "1.5.2",
+                            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                         },
                         "balanced-match": {
-                            "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                            "version": "0.4.2",
+                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                             "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
                         },
                         "brace-expansion": {
-                            "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                            "version": "1.1.6",
+                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                             "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                             "requires": {
-                                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                "balanced-match": "^0.4.1",
+                                "concat-map": "0.0.1"
                             }
                         },
                         "browser-stdout": {
@@ -14037,17 +14055,19 @@
                             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
                         },
                         "camelcase": {
-                            "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                            "version": "1.2.1",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                             "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                             "optional": true
                         },
                         "center-align": {
-                            "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                             "optional": true,
                             "requires": {
-                                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                                "align-text": "^0.1.3",
+                                "lazy-cache": "^1.0.3"
                             }
                         },
                         "chai": {
@@ -14055,12 +14075,12 @@
                             "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.1.tgz",
                             "integrity": "sha1-ZuISeebzxkFf+CMYeCJ5AOIXGzk=",
                             "requires": {
-                                "assertion-error": "1.0.2",
-                                "check-error": "1.0.2",
-                                "deep-eql": "2.0.2",
-                                "get-func-name": "2.0.0",
-                                "pathval": "1.1.0",
-                                "type-detect": "4.0.3"
+                                "assertion-error": "^1.0.1",
+                                "check-error": "^1.0.1",
+                                "deep-eql": "^2.0.1",
+                                "get-func-name": "^2.0.0",
+                                "pathval": "^1.0.0",
+                                "type-detect": "^4.0.0"
                             }
                         },
                         "chalk": {
@@ -14068,9 +14088,9 @@
                             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
                             "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                             "requires": {
-                                "ansi-styles": "3.2.0",
-                                "escape-string-regexp": "1.0.5",
-                                "supports-color": "4.2.1"
+                                "ansi-styles": "^3.1.0",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^4.0.0"
                             },
                             "dependencies": {
                                 "has-flag": {
@@ -14083,7 +14103,7 @@
                                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
                                     "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
                                     "requires": {
-                                        "has-flag": "2.0.0"
+                                        "has-flag": "^2.0.0"
                                     }
                                 }
                             }
@@ -14094,17 +14114,19 @@
                             "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
                         },
                         "cliui": {
-                            "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                             "optional": true,
                             "requires": {
-                                "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                                "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
+                                "wordwrap": "0.0.2"
                             },
                             "dependencies": {
                                 "wordwrap": {
-                                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                    "version": "0.0.2",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                                     "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                                     "optional": true
                                 }
@@ -14115,7 +14137,7 @@
                             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
                             "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                             "requires": {
-                                "color-name": "1.1.3"
+                                "color-name": "^1.1.1"
                             }
                         },
                         "color-name": {
@@ -14128,11 +14150,12 @@
                             "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                             "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                             "requires": {
-                                "graceful-readlink": "1.0.1"
+                                "graceful-readlink": ">= 1.0.0"
                             }
                         },
                         "concat-map": {
-                            "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         },
                         "debug": {
@@ -14144,7 +14167,8 @@
                             }
                         },
                         "decamelize": {
-                            "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                             "optional": true
                         },
@@ -14153,7 +14177,7 @@
                             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
                             "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
                             "requires": {
-                                "type-detect": "3.0.0"
+                                "type-detect": "^3.0.0"
                             },
                             "dependencies": {
                                 "type-detect": {
@@ -14164,7 +14188,8 @@
                             }
                         },
                         "deep-is": {
-                            "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
                         },
                         "diff": {
@@ -14178,40 +14203,46 @@
                             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                         },
                         "escodegen": {
-                            "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+                            "version": "1.8.1",
+                            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
                             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
                             "requires": {
-                                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+                                "esprima": "^2.7.1",
+                                "estraverse": "^1.9.1",
+                                "esutils": "^2.0.2",
+                                "optionator": "^0.8.1",
+                                "source-map": "~0.2.0"
                             },
                             "dependencies": {
                                 "source-map": {
-                                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                                    "version": "0.2.0",
+                                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                                     "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                                     "optional": true,
                                     "requires": {
-                                        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                                        "amdefine": ">=0.0.4"
                                     }
                                 }
                             }
                         },
                         "esprima": {
-                            "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                            "version": "2.7.3",
+                            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
                             "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
                         },
                         "estraverse": {
-                            "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                            "version": "1.9.3",
+                            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
                             "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
                         },
                         "esutils": {
-                            "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                         },
                         "fast-levenshtein": {
-                            "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
+                            "version": "2.0.5",
+                            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
                             "integrity": "sha1-vTMUV0RRmrHDbD7p8x8I6QebZ/I="
                         },
                         "fs.realpath": {
@@ -14225,14 +14256,15 @@
                             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
                         },
                         "glob": {
-                            "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                            "version": "5.0.15",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                             "requires": {
-                                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         },
                         "graceful-readlink": {
@@ -14246,74 +14278,82 @@
                             "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
                         },
                         "handlebars": {
-                            "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+                            "version": "4.0.6",
+                            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
                             "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
                             "requires": {
-                                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz"
+                                "async": "^1.4.0",
+                                "optimist": "^0.6.1",
+                                "source-map": "^0.4.4",
+                                "uglify-js": "^2.6"
                             },
                             "dependencies": {
                                 "source-map": {
-                                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                                    "version": "0.4.4",
+                                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                                     "requires": {
-                                        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                                        "amdefine": ">=0.0.4"
                                     }
                                 }
                             }
                         },
                         "has-flag": {
-                            "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                             "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
                         },
                         "inflight": {
-                            "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                            "version": "1.0.6",
+                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                             "requires": {
-                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                             }
                         },
                         "inherits": {
-                            "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                         },
                         "is-buffer": {
-                            "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
                             "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
                         },
                         "isexe": {
-                            "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
                             "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
                         },
                         "istanbul": {
                             "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
                             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
                             "requires": {
-                                "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                                "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-                                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                                "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                                "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-                                "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-                                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                                "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-                                "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                                "abbrev": "1.0.x",
+                                "async": "1.x",
+                                "escodegen": "1.8.x",
+                                "esprima": "2.7.x",
+                                "glob": "^5.0.15",
+                                "handlebars": "^4.0.1",
+                                "js-yaml": "3.x",
+                                "mkdirp": "0.5.x",
+                                "nopt": "3.x",
+                                "once": "1.x",
+                                "resolve": "1.1.x",
+                                "supports-color": "^3.1.0",
+                                "which": "^1.1.1",
+                                "wordwrap": "^1.0.0"
                             }
                         },
                         "js-yaml": {
-                            "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                            "version": "3.7.0",
+                            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
                             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
                             "requires": {
-                                "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+                                "argparse": "^1.0.7",
+                                "esprima": "^2.6.0"
                             }
                         },
                         "json3": {
@@ -14322,23 +14362,26 @@
                             "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
                         },
                         "kind-of": {
-                            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
                             "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
                             "requires": {
-                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                "is-buffer": "^1.0.2"
                             }
                         },
                         "lazy-cache": {
-                            "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                            "version": "1.0.4",
+                            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                             "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                             "optional": true
                         },
                         "levn": {
-                            "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                             "requires": {
-                                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2"
                             }
                         },
                         "lodash._baseassign": {
@@ -14346,8 +14389,8 @@
                             "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
                             "requires": {
-                                "lodash._basecopy": "3.0.1",
-                                "lodash.keys": "3.1.2"
+                                "lodash._basecopy": "^3.0.0",
+                                "lodash.keys": "^3.0.0"
                             }
                         },
                         "lodash._basecopy": {
@@ -14375,9 +14418,9 @@
                             "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
                             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
                             "requires": {
-                                "lodash._baseassign": "3.2.0",
-                                "lodash._basecreate": "3.0.3",
-                                "lodash._isiterateecall": "3.0.9"
+                                "lodash._baseassign": "^3.0.0",
+                                "lodash._basecreate": "^3.0.0",
+                                "lodash._isiterateecall": "^3.0.0"
                             }
                         },
                         "lodash.isarguments": {
@@ -14395,35 +14438,40 @@
                             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                             "requires": {
-                                "lodash._getnative": "3.9.1",
-                                "lodash.isarguments": "3.1.0",
-                                "lodash.isarray": "3.0.4"
+                                "lodash._getnative": "^3.0.0",
+                                "lodash.isarguments": "^3.0.0",
+                                "lodash.isarray": "^3.0.0"
                             }
                         },
                         "longest": {
-                            "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                         },
                         "minimatch": {
-                            "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                            "version": "3.0.3",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                             "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                             "requires": {
-                                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                                "brace-expansion": "^1.0.0"
                             }
                         },
                         "minimist": {
-                            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                            "version": "0.0.10",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                             "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
                         },
                         "mkdirp": {
-                            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                            "version": "0.5.1",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                             "requires": {
-                                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                "minimist": "0.0.8"
                             },
                             "dependencies": {
                                 "minimist": {
-                                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                                    "version": "0.0.8",
+                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                                 }
                             }
@@ -14442,8 +14490,8 @@
                                 "growl": "1.9.2",
                                 "json3": "3.3.2",
                                 "lodash.create": "3.1.1",
-                                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+                                "mkdirp": "0.5.1",
+                                "supports-color": "3.1.2"
                             },
                             "dependencies": {
                                 "glob": {
@@ -14451,12 +14499,12 @@
                                     "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                                     "requires": {
-                                        "fs.realpath": "1.0.0",
-                                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                        "fs.realpath": "^1.0.0",
+                                        "inflight": "^1.0.4",
+                                        "inherits": "2",
+                                        "minimatch": "^3.0.2",
+                                        "once": "^1.3.0",
+                                        "path-is-absolute": "^1.0.0"
                                     }
                                 }
                             }
@@ -14467,47 +14515,53 @@
                             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                         },
                         "nopt": {
-                            "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                            "version": "3.0.6",
+                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                             "requires": {
-                                "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                                "abbrev": "1"
                             }
                         },
                         "once": {
-                            "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "requires": {
-                                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                "wrappy": "1"
                             }
                         },
                         "optimist": {
-                            "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                             "requires": {
-                                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                                "minimist": "~0.0.1",
+                                "wordwrap": "~0.0.2"
                             },
                             "dependencies": {
                                 "wordwrap": {
-                                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                                    "version": "0.0.3",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                                     "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
                                 }
                             }
                         },
                         "optionator": {
-                            "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                            "version": "0.8.2",
+                            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
                             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
                             "requires": {
-                                "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                                "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz",
-                                "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                                "deep-is": "~0.1.3",
+                                "fast-levenshtein": "~2.0.4",
+                                "levn": "~0.3.0",
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2",
+                                "wordwrap": "~1.0.0"
                             }
                         },
                         "path-is-absolute": {
-                            "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
                         },
                         "pathval": {
@@ -14520,9 +14574,9 @@
                             "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
                             "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                             "requires": {
-                                "chalk": "2.1.0",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                                "supports-color": "4.2.1"
+                                "chalk": "^2.1.0",
+                                "source-map": "^0.5.6",
+                                "supports-color": "^4.2.1"
                             },
                             "dependencies": {
                                 "has-flag": {
@@ -14535,7 +14589,7 @@
                                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
                                     "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
                                     "requires": {
-                                        "has-flag": "2.0.0"
+                                        "has-flag": "^2.0.0"
                                     }
                                 }
                             }
@@ -14545,852 +14599,987 @@
                             "resolved": "https://registry.npmjs.org/postcss-wee-syntax/-/postcss-wee-syntax-3.0.0.tgz",
                             "integrity": "sha512-FNhQGct9M/d4VeT0997SDfKW51c5b7CMAgsR04zJgRVbTFHOCbAwps1gtxqNVbGW6GRDqfDIjrMBqQDkcCySQw==",
                             "requires": {
-                                "postcss": "6.0.9"
+                                "postcss": "^6.0.9"
                             },
                             "dependencies": {
                                 "abbrev": {
-                                    "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                                    "version": "1.0.9",
+                                    "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
                                     "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
                                 },
                                 "ajv": {
-                                    "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                                    "version": "4.11.8",
+                                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                                     "requires": {
-                                        "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                                        "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+                                        "co": "^4.6.0",
+                                        "json-stable-stringify": "^1.0.1"
                                     }
                                 },
                                 "align-text": {
-                                    "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                                    "version": "0.1.4",
+                                    "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                                     "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                                     "requires": {
-                                        "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                        "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                        "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                        "kind-of": "^3.0.2",
+                                        "longest": "^1.0.1",
+                                        "repeat-string": "^1.5.2"
                                     }
                                 },
                                 "amdefine": {
-                                    "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                                    "version": "1.0.1",
+                                    "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
                                     "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
                                 },
                                 "ansi-regex": {
-                                    "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                                    "version": "2.1.1",
+                                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                                     "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                                 },
                                 "ansi-styles": {
-                                    "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                                    "version": "3.2.0",
+                                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                                     "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
                                     "requires": {
-                                        "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+                                        "color-convert": "^1.9.0"
                                     }
                                 },
                                 "argparse": {
-                                    "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                                    "version": "1.0.9",
+                                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                                     "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                                     "requires": {
-                                        "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                                        "sprintf-js": "~1.0.2"
                                     }
                                 },
                                 "array-differ": {
-                                    "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
                                     "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
                                 },
                                 "array-uniq": {
-                                    "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                                    "version": "1.0.3",
+                                    "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
                                     "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
                                 },
                                 "asn1": {
-                                    "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                                    "version": "0.2.3",
+                                    "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                                     "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                                 },
                                 "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                                    "version": "0.2.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                                     "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
                                 },
                                 "assertion-error": {
-                                    "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
                                     "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
                                 },
                                 "async": {
-                                    "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                                    "version": "1.5.2",
+                                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                                     "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                                 },
                                 "asynckit": {
-                                    "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                                    "version": "0.4.0",
+                                    "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                                     "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                                 },
                                 "aws-sign2": {
-                                    "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                                    "version": "0.6.0",
+                                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
                                     "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
                                 },
                                 "aws4": {
-                                    "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                                    "version": "1.6.0",
+                                    "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
                                     "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
                                 },
                                 "balanced-match": {
-                                    "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                                    "version": "0.4.2",
+                                    "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                                     "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
                                 },
                                 "bcrypt-pbkdf": {
-                                    "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                                    "version": "1.0.1",
+                                    "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                                     "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                                     "optional": true,
                                     "requires": {
-                                        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                        "tweetnacl": "^0.14.3"
                                     }
                                 },
                                 "beeper": {
-                                    "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+                                    "version": "1.1.1",
+                                    "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
                                     "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
                                 },
                                 "boom": {
-                                    "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                                    "version": "2.10.1",
+                                    "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                                     "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                                     "requires": {
-                                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                        "hoek": "2.x.x"
                                     }
                                 },
                                 "brace-expansion": {
-                                    "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                                    "version": "1.1.6",
+                                    "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                                     "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                                     "requires": {
-                                        "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                        "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                        "balanced-match": "^0.4.1",
+                                        "concat-map": "0.0.1"
                                     }
                                 },
                                 "browser-stdout": {
-                                    "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
                                     "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
                                 },
                                 "camelcase": {
-                                    "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                                    "version": "1.2.1",
+                                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                                     "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                                     "optional": true
                                 },
                                 "caseless": {
-                                    "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                                    "version": "0.12.0",
+                                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
                                     "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
                                 },
                                 "center-align": {
-                                    "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                                    "version": "0.1.3",
+                                    "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                                     "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                                     "optional": true,
                                     "requires": {
-                                        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                        "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                                        "align-text": "^0.1.3",
+                                        "lazy-cache": "^1.0.3"
                                     }
                                 },
                                 "chai": {
                                     "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
                                     "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
                                     "requires": {
-                                        "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-                                        "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-                                        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+                                        "assertion-error": "^1.0.1",
+                                        "deep-eql": "^0.1.3",
+                                        "type-detect": "^1.0.0"
                                     }
                                 },
                                 "chalk": {
                                     "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
                                     "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
                                     "requires": {
-                                        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+                                        "ansi-styles": "^3.1.0",
+                                        "escape-string-regexp": "^1.0.5",
+                                        "supports-color": "^4.0.0"
                                     },
                                     "dependencies": {
                                         "has-flag": {
-                                            "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                                            "version": "2.0.0",
+                                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
                                             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                                         },
                                         "supports-color": {
-                                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                                            "version": "4.2.1",
+                                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
                                             "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
                                             "requires": {
-                                                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                                                "has-flag": "^2.0.0"
                                             }
                                         }
                                     }
                                 },
                                 "cliui": {
-                                    "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                                    "version": "2.1.0",
+                                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                                     "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                                     "optional": true,
                                     "requires": {
-                                        "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                                        "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                                        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                        "center-align": "^0.1.1",
+                                        "right-align": "^0.1.1",
+                                        "wordwrap": "0.0.2"
                                     },
                                     "dependencies": {
                                         "wordwrap": {
-                                            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                            "version": "0.0.2",
+                                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                                             "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                                             "optional": true
                                         }
                                     }
                                 },
                                 "clone": {
-                                    "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                                     "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
                                 },
                                 "clone-stats": {
-                                    "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                                    "version": "0.0.1",
+                                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                                     "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
                                 },
                                 "co": {
-                                    "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                                    "version": "4.6.0",
+                                    "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
                                     "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
                                 },
                                 "color-convert": {
-                                    "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                                    "version": "1.9.0",
+                                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
                                     "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                                     "requires": {
-                                        "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                                        "color-name": "^1.1.1"
                                     }
                                 },
                                 "color-name": {
-                                    "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                                    "version": "1.1.3",
+                                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
                                     "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
                                 },
                                 "combined-stream": {
-                                    "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                                    "version": "1.0.5",
+                                    "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                                     "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                                     "requires": {
-                                        "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                                        "delayed-stream": "~1.0.0"
                                     }
                                 },
                                 "commander": {
-                                    "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                                    "version": "2.9.0",
+                                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                                     "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                                     "requires": {
-                                        "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                        "graceful-readlink": ">= 1.0.0"
                                     }
                                 },
                                 "concat-map": {
-                                    "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                    "version": "0.0.1",
+                                    "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                     "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                                 },
                                 "core-util-is": {
-                                    "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                                     "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                                 },
                                 "cryptiles": {
-                                    "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                                    "version": "2.0.5",
+                                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                                     "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                                     "requires": {
-                                        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                                        "boom": "2.x.x"
                                     }
                                 },
                                 "dashdash": {
-                                    "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                                    "version": "1.14.1",
+                                    "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                                     "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                                     "requires": {
-                                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                        "assert-plus": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "assert-plus": {
-                                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                         }
                                     }
                                 },
                                 "dateformat": {
-                                    "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
                                     "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
                                 },
                                 "debug": {
-                                    "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                                    "version": "2.6.8",
+                                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                                     "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                                     "requires": {
-                                        "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                                        "ms": "2.0.0"
                                     }
                                 },
                                 "decamelize": {
-                                    "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                                    "version": "1.2.0",
+                                    "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                                     "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                                     "optional": true
                                 },
                                 "deep-eql": {
-                                    "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+                                    "version": "0.1.3",
+                                    "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
                                     "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
                                     "requires": {
-                                        "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                                        "type-detect": "0.1.1"
                                     },
                                     "dependencies": {
                                         "type-detect": {
-                                            "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                                            "version": "0.1.1",
+                                            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                                             "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
                                         }
                                     }
                                 },
                                 "deep-is": {
-                                    "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                                    "version": "0.1.3",
+                                    "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                                     "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
                                 },
                                 "delayed-stream": {
-                                    "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                                     "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                                 },
                                 "diff": {
-                                    "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+                                    "version": "3.2.0",
+                                    "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
                                     "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
                                 },
                                 "duplexer2": {
-                                    "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                                    "version": "0.0.2",
+                                    "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                                     "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
                                     "requires": {
-                                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+                                        "readable-stream": "~1.1.9"
                                     }
                                 },
                                 "ecc-jsbn": {
-                                    "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                                    "version": "0.1.1",
+                                    "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                                     "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                                     "optional": true,
                                     "requires": {
-                                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                                        "jsbn": "~0.1.0"
                                     }
                                 },
                                 "escape-string-regexp": {
-                                    "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                                    "version": "1.0.5",
+                                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                                     "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                                 },
                                 "escodegen": {
-                                    "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+                                    "version": "1.8.1",
+                                    "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
                                     "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
                                     "requires": {
-                                        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                                        "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                                        "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                        "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-                                        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+                                        "esprima": "^2.7.1",
+                                        "estraverse": "^1.9.1",
+                                        "esutils": "^2.0.2",
+                                        "optionator": "^0.8.1",
+                                        "source-map": "~0.2.0"
                                     },
                                     "dependencies": {
                                         "source-map": {
-                                            "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                                            "version": "0.2.0",
+                                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                                             "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                                             "optional": true,
                                             "requires": {
-                                                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                                                "amdefine": ">=0.0.4"
                                             }
                                         }
                                     }
                                 },
                                 "esprima": {
-                                    "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                                    "version": "2.7.3",
+                                    "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
                                     "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
                                 },
                                 "estraverse": {
-                                    "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                                    "version": "1.9.3",
+                                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
                                     "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
                                 },
                                 "esutils": {
-                                    "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                                    "version": "2.0.2",
+                                    "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                                     "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                                 },
                                 "extend": {
-                                    "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                                    "version": "3.0.1",
+                                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                                     "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
                                 },
                                 "extsprintf": {
-                                    "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
                                     "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
                                 },
                                 "fancy-log": {
-                                    "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
                                     "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
                                     "requires": {
-                                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                        "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+                                        "chalk": "^1.1.1",
+                                        "time-stamp": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "ansi-styles": {
-                                            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                            "version": "2.2.1",
+                                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
                                         },
                                         "chalk": {
-                                            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                            "version": "1.1.3",
+                                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                                             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                                             "requires": {
-                                                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                                "ansi-styles": "^2.2.1",
+                                                "escape-string-regexp": "^1.0.2",
+                                                "has-ansi": "^2.0.0",
+                                                "strip-ansi": "^3.0.0",
+                                                "supports-color": "^2.0.0"
                                             }
                                         },
                                         "supports-color": {
-                                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                            "version": "2.0.0",
+                                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                         }
                                     }
                                 },
                                 "fast-levenshtein": {
-                                    "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                                    "version": "2.0.6",
+                                    "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
                                     "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
                                 },
                                 "forever-agent": {
-                                    "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                                    "version": "0.6.1",
+                                    "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                                     "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
                                 },
                                 "form-data": {
-                                    "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                                    "version": "2.1.4",
+                                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
                                     "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                                     "requires": {
-                                        "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
+                                        "asynckit": "^0.4.0",
+                                        "combined-stream": "^1.0.5",
+                                        "mime-types": "^2.1.12"
                                     }
                                 },
                                 "fs.realpath": {
-                                    "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                                     "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
                                 },
                                 "getpass": {
-                                    "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                                    "version": "0.1.7",
+                                    "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                                     "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                                     "requires": {
-                                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                        "assert-plus": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "assert-plus": {
-                                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                         }
                                     }
                                 },
                                 "glob": {
-                                    "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                                    "version": "5.0.15",
+                                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                                     "requires": {
-                                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                        "inflight": "^1.0.4",
+                                        "inherits": "2",
+                                        "minimatch": "2 || 3",
+                                        "once": "^1.3.0",
+                                        "path-is-absolute": "^1.0.0"
                                     }
                                 },
                                 "glogg": {
-                                    "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                                     "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
                                     "requires": {
-                                        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                                        "sparkles": "^1.0.0"
                                     }
                                 },
                                 "graceful-readlink": {
-                                    "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                                    "version": "1.0.1",
+                                    "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                                     "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
                                 },
                                 "growl": {
-                                    "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+                                    "version": "1.9.2",
+                                    "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
                                     "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
                                 },
                                 "gulp-util": {
-                                    "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+                                    "version": "3.0.8",
+                                    "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
                                     "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
                                     "requires": {
-                                        "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-                                        "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                                        "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-                                        "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                        "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-                                        "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-                                        "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-                                        "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-                                        "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-                                        "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-                                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                                        "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-                                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                        "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                                        "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                                        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                                        "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                                        "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+                                        "array-differ": "^1.0.0",
+                                        "array-uniq": "^1.0.2",
+                                        "beeper": "^1.0.0",
+                                        "chalk": "^1.0.0",
+                                        "dateformat": "^2.0.0",
+                                        "fancy-log": "^1.1.0",
+                                        "gulplog": "^1.0.0",
+                                        "has-gulplog": "^0.1.0",
+                                        "lodash._reescape": "^3.0.0",
+                                        "lodash._reevaluate": "^3.0.0",
+                                        "lodash._reinterpolate": "^3.0.0",
+                                        "lodash.template": "^3.0.0",
+                                        "minimist": "^1.1.0",
+                                        "multipipe": "^0.1.2",
+                                        "object-assign": "^3.0.0",
+                                        "replace-ext": "0.0.1",
+                                        "through2": "^2.0.0",
+                                        "vinyl": "^0.5.0"
                                     },
                                     "dependencies": {
                                         "ansi-styles": {
-                                            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                            "version": "2.2.1",
+                                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
                                         },
                                         "chalk": {
-                                            "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                            "version": "1.1.3",
+                                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                                             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                                             "requires": {
-                                                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                                "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                                "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                                "ansi-styles": "^2.2.1",
+                                                "escape-string-regexp": "^1.0.2",
+                                                "has-ansi": "^2.0.0",
+                                                "strip-ansi": "^3.0.0",
+                                                "supports-color": "^2.0.0"
                                             }
                                         },
                                         "supports-color": {
-                                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                            "version": "2.0.0",
+                                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                         }
                                     }
                                 },
                                 "gulplog": {
-                                    "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
                                     "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
                                     "requires": {
-                                        "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+                                        "glogg": "^1.0.0"
                                     }
                                 },
                                 "handlebars": {
-                                    "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+                                    "version": "4.0.6",
+                                    "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
                                     "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
                                     "requires": {
-                                        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                                        "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                                        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                                        "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz"
+                                        "async": "^1.4.0",
+                                        "optimist": "^0.6.1",
+                                        "source-map": "^0.4.4",
+                                        "uglify-js": "^2.6"
                                     },
                                     "dependencies": {
                                         "source-map": {
-                                            "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                                            "version": "0.4.4",
+                                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                                             "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                                             "requires": {
-                                                "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                                                "amdefine": ">=0.0.4"
                                             }
                                         }
                                     }
                                 },
                                 "har-schema": {
-                                    "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                                    "version": "1.0.5",
+                                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
                                     "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
                                 },
                                 "har-validator": {
-                                    "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                                    "version": "4.2.1",
+                                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
                                     "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                                     "requires": {
-                                        "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                                        "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                                        "ajv": "^4.9.1",
+                                        "har-schema": "^1.0.5"
                                     }
                                 },
                                 "has-ansi": {
-                                    "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                                     "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                                     "requires": {
-                                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                        "ansi-regex": "^2.0.0"
                                     }
                                 },
                                 "has-flag": {
-                                    "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                                     "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
                                 },
                                 "has-gulplog": {
-                                    "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+                                    "version": "0.1.0",
+                                    "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
                                     "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
                                     "requires": {
-                                        "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                                        "sparkles": "^1.0.0"
                                     }
                                 },
                                 "hawk": {
-                                    "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                                    "version": "3.1.3",
+                                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                                     "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                                     "requires": {
-                                        "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                                        "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                                        "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                        "boom": "2.x.x",
+                                        "cryptiles": "2.x.x",
+                                        "hoek": "2.x.x",
+                                        "sntp": "1.x.x"
                                     }
                                 },
                                 "hoek": {
-                                    "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                                    "version": "2.16.3",
+                                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                                     "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                                 },
                                 "http-signature": {
-                                    "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                                    "version": "1.1.1",
+                                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                                     "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                                     "requires": {
-                                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                                        "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-                                        "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+                                        "assert-plus": "^0.2.0",
+                                        "jsprim": "^1.2.2",
+                                        "sshpk": "^1.7.0"
                                     }
                                 },
                                 "inflight": {
-                                    "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                                    "version": "1.0.6",
+                                    "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                                     "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                                     "requires": {
-                                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                        "once": "^1.3.0",
+                                        "wrappy": "1"
                                     }
                                 },
                                 "inherits": {
-                                    "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                                    "version": "2.0.3",
+                                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                                     "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                                 },
                                 "is-buffer": {
-                                    "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                                    "version": "1.1.4",
+                                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
                                     "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
                                 },
                                 "is-typedarray": {
-                                    "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
                                     "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
                                 },
                                 "isarray": {
-                                    "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                    "version": "0.0.1",
+                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                                     "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                                 },
                                 "isexe": {
-                                    "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                                    "version": "1.1.2",
+                                    "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
                                     "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
                                 },
                                 "isstream": {
-                                    "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                                    "version": "0.1.2",
+                                    "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                                     "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
                                 },
                                 "istanbul": {
                                     "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
                                     "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
                                     "requires": {
-                                        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                                        "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                                        "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-                                        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                                        "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                                        "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-                                        "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-                                        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                                        "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                        "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                                        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                                        "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-                                        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                                        "abbrev": "1.0.x",
+                                        "async": "1.x",
+                                        "escodegen": "1.8.x",
+                                        "esprima": "2.7.x",
+                                        "glob": "^5.0.15",
+                                        "handlebars": "^4.0.1",
+                                        "js-yaml": "3.x",
+                                        "mkdirp": "0.5.x",
+                                        "nopt": "3.x",
+                                        "once": "1.x",
+                                        "resolve": "1.1.x",
+                                        "supports-color": "^3.1.0",
+                                        "which": "^1.1.1",
+                                        "wordwrap": "^1.0.0"
                                     },
                                     "dependencies": {
                                         "supports-color": {
-                                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                                            "version": "3.2.3",
+                                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                                             "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                                             "requires": {
-                                                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                                                "has-flag": "^1.0.0"
                                             }
                                         }
                                     }
                                 },
                                 "js-yaml": {
-                                    "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                                    "version": "3.7.0",
+                                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
                                     "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
                                     "requires": {
-                                        "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                                        "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+                                        "argparse": "^1.0.7",
+                                        "esprima": "^2.6.0"
                                     }
                                 },
                                 "jsbn": {
-                                    "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                                    "version": "0.1.1",
+                                    "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                                     "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                                     "optional": true
                                 },
                                 "json-schema": {
-                                    "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                                    "version": "0.2.3",
+                                    "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                                     "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                                 },
                                 "json-stable-stringify": {
-                                    "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                                    "version": "1.0.1",
+                                    "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                                     "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                                     "requires": {
-                                        "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                                        "jsonify": "~0.0.0"
                                     }
                                 },
                                 "json-stringify-safe": {
-                                    "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                                    "version": "5.0.1",
+                                    "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                                     "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
                                 },
                                 "json3": {
-                                    "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+                                    "version": "3.3.2",
+                                    "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                                     "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
                                 },
                                 "jsonify": {
-                                    "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                                    "version": "0.0.0",
+                                    "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                                     "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
                                 },
                                 "jsprim": {
-                                    "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                                    "version": "1.4.1",
+                                    "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
                                     "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
                                     "requires": {
-                                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-                                        "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                                        "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+                                        "assert-plus": "1.0.0",
+                                        "extsprintf": "1.3.0",
+                                        "json-schema": "0.2.3",
+                                        "verror": "1.10.0"
                                     },
                                     "dependencies": {
                                         "assert-plus": {
-                                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                         }
                                     }
                                 },
                                 "kind-of": {
-                                    "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
                                     "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
                                     "requires": {
-                                        "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                        "is-buffer": "^1.0.2"
                                     }
                                 },
                                 "lazy-cache": {
-                                    "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                                    "version": "1.0.4",
+                                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                                     "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                                     "optional": true
                                 },
                                 "levn": {
-                                    "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                                    "version": "0.3.0",
+                                    "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                                     "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                                     "requires": {
-                                        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                                        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                                        "prelude-ls": "~1.1.2",
+                                        "type-check": "~0.3.2"
                                     }
                                 },
                                 "load-resources": {
-                                    "version": "https://registry.npmjs.org/load-resources/-/load-resources-0.1.1.tgz",
+                                    "version": "0.1.1",
+                                    "resolved": "https://registry.npmjs.org/load-resources/-/load-resources-0.1.1.tgz",
                                     "integrity": "sha1-PFiPn7v5lnmS8+EVfcUk8gI+Fm4=",
                                     "requires": {
-                                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                        "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+                                        "escape-string-regexp": "^1.0.3",
+                                        "request": "^2.55.0"
                                     }
                                 },
                                 "lodash._baseassign": {
-                                    "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                                    "version": "3.2.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                                     "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
                                     "requires": {
-                                        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                                        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                                        "lodash._basecopy": "^3.0.0",
+                                        "lodash.keys": "^3.0.0"
                                     }
                                 },
                                 "lodash._basecopy": {
-                                    "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                                    "version": "3.0.1",
+                                    "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                                     "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
                                 },
                                 "lodash._basecreate": {
-                                    "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                                    "version": "3.0.3",
+                                    "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
                                     "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
                                 },
                                 "lodash._basetostring": {
-                                    "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                                    "version": "3.0.1",
+                                    "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                                     "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
                                 },
                                 "lodash._basevalues": {
-                                    "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
                                     "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
                                 },
                                 "lodash._getnative": {
-                                    "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                                    "version": "3.9.1",
+                                    "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                                     "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
                                 },
                                 "lodash._isiterateecall": {
-                                    "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                                    "version": "3.0.9",
+                                    "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                                     "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
                                 },
                                 "lodash._reescape": {
-                                    "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
                                     "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
                                 },
                                 "lodash._reevaluate": {
-                                    "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
                                     "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
                                 },
                                 "lodash._reinterpolate": {
-                                    "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
                                     "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
                                 },
                                 "lodash._root": {
-                                    "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                                    "version": "3.0.1",
+                                    "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                                     "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
                                 },
                                 "lodash.create": {
-                                    "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+                                    "version": "3.1.1",
+                                    "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
                                     "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
                                     "requires": {
-                                        "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                                        "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-                                        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                        "lodash._baseassign": "^3.0.0",
+                                        "lodash._basecreate": "^3.0.0",
+                                        "lodash._isiterateecall": "^3.0.0"
                                     }
                                 },
                                 "lodash.escape": {
-                                    "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                                    "version": "3.2.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                                     "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
                                     "requires": {
-                                        "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                                        "lodash._root": "^3.0.0"
                                     }
                                 },
                                 "lodash.isarguments": {
-                                    "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
                                     "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
                                 },
                                 "lodash.isarray": {
-                                    "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                                    "version": "3.0.4",
+                                    "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                                     "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
                                 },
                                 "lodash.keys": {
-                                    "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                                    "version": "3.1.2",
+                                    "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                                     "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                                     "requires": {
-                                        "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                                        "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                                        "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                        "lodash._getnative": "^3.0.0",
+                                        "lodash.isarguments": "^3.0.0",
+                                        "lodash.isarray": "^3.0.0"
                                     }
                                 },
                                 "lodash.restparam": {
-                                    "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                                    "version": "3.6.1",
+                                    "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                                     "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
                                 },
                                 "lodash.template": {
-                                    "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                                    "version": "3.6.2",
+                                    "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                                     "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
                                     "requires": {
-                                        "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                                        "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                                        "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-                                        "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                                        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-                                        "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                                        "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                                        "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+                                        "lodash._basecopy": "^3.0.0",
+                                        "lodash._basetostring": "^3.0.0",
+                                        "lodash._basevalues": "^3.0.0",
+                                        "lodash._isiterateecall": "^3.0.0",
+                                        "lodash._reinterpolate": "^3.0.0",
+                                        "lodash.escape": "^3.0.0",
+                                        "lodash.keys": "^3.0.0",
+                                        "lodash.restparam": "^3.0.0",
+                                        "lodash.templatesettings": "^3.0.0"
                                     }
                                 },
                                 "lodash.templatesettings": {
-                                    "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                                    "version": "3.1.1",
+                                    "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
                                     "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
                                     "requires": {
-                                        "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                                        "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+                                        "lodash._reinterpolate": "^3.0.0",
+                                        "lodash.escape": "^3.0.0"
                                     }
                                 },
                                 "longest": {
-                                    "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                                    "version": "1.0.1",
+                                    "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                                     "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                                 },
                                 "mime-db": {
-                                    "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+                                    "version": "1.29.0",
+                                    "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
                                     "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
                                 },
                                 "mime-types": {
-                                    "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                                    "version": "2.1.16",
+                                    "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
                                     "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
                                     "requires": {
-                                        "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                                        "mime-db": "~1.29.0"
                                     }
                                 },
                                 "minimatch": {
-                                    "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                                    "version": "3.0.3",
+                                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                                     "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                                     "requires": {
-                                        "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                                        "brace-expansion": "^1.0.0"
                                     }
                                 },
                                 "minimist": {
-                                    "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                                    "version": "1.2.0",
+                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                                 },
                                 "mkdirp": {
-                                    "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                                    "version": "0.5.1",
+                                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                                     "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                                     "requires": {
-                                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                        "minimist": "0.0.8"
                                     },
                                     "dependencies": {
                                         "minimist": {
-                                            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                                            "version": "0.0.8",
+                                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                                             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                                         }
                                     }
@@ -15399,102 +15588,115 @@
                                     "version": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
                                     "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
                                     "requires": {
-                                        "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-                                        "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                                        "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                                        "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-                                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                        "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                                        "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-                                        "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-                                        "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-                                        "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                                        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+                                        "browser-stdout": "1.3.0",
+                                        "commander": "2.9.0",
+                                        "debug": "2.6.8",
+                                        "diff": "3.2.0",
+                                        "escape-string-regexp": "1.0.5",
+                                        "glob": "7.1.1",
+                                        "growl": "1.9.2",
+                                        "json3": "3.3.2",
+                                        "lodash.create": "3.1.1",
+                                        "mkdirp": "0.5.1",
+                                        "supports-color": "3.1.2"
                                     },
                                     "dependencies": {
                                         "glob": {
-                                            "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                                            "version": "7.1.1",
+                                            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                                             "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                                             "requires": {
-                                                "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                                                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                                                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                                "fs.realpath": "^1.0.0",
+                                                "inflight": "^1.0.4",
+                                                "inherits": "2",
+                                                "minimatch": "^3.0.2",
+                                                "once": "^1.3.0",
+                                                "path-is-absolute": "^1.0.0"
                                             }
                                         }
                                     }
                                 },
                                 "ms": {
-                                    "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                                 },
                                 "multipipe": {
-                                    "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                                    "version": "0.1.2",
+                                    "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
                                     "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
                                     "requires": {
-                                        "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                                        "duplexer2": "0.0.2"
                                     }
                                 },
                                 "nopt": {
-                                    "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                                    "version": "3.0.6",
+                                    "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                                     "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                                     "requires": {
-                                        "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                                        "abbrev": "1"
                                     }
                                 },
                                 "oauth-sign": {
-                                    "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                                    "version": "0.8.2",
+                                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
                                     "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
                                 },
                                 "object-assign": {
-                                    "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                                    "version": "3.0.0",
+                                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                                     "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
                                 },
                                 "once": {
-                                    "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                                    "version": "1.4.0",
+                                    "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                                     "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                                     "requires": {
-                                        "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                        "wrappy": "1"
                                     }
                                 },
                                 "optimist": {
-                                    "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                                    "version": "0.6.1",
+                                    "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                                     "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                                     "requires": {
-                                        "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                                        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                                        "minimist": "~0.0.1",
+                                        "wordwrap": "~0.0.2"
                                     },
                                     "dependencies": {
                                         "minimist": {
-                                            "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                                            "version": "0.0.10",
+                                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                                             "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
                                         },
                                         "wordwrap": {
-                                            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                                            "version": "0.0.3",
+                                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                                             "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
                                         }
                                     }
                                 },
                                 "optionator": {
-                                    "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                                    "version": "0.8.2",
+                                    "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
                                     "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
                                     "requires": {
-                                        "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                                        "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                                        "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                                        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                                        "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                                        "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                                        "deep-is": "~0.1.3",
+                                        "fast-levenshtein": "~2.0.4",
+                                        "levn": "~0.3.0",
+                                        "prelude-ls": "~1.1.2",
+                                        "type-check": "~0.3.2",
+                                        "wordwrap": "~1.0.0"
                                     }
                                 },
                                 "path-is-absolute": {
-                                    "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                                    "version": "1.0.1",
+                                    "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                                     "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
                                 },
                                 "performance-now": {
-                                    "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                                    "version": "0.2.0",
+                                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
                                     "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
                                 },
                                 "postcss": {
@@ -15502,9 +15704,9 @@
                                     "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
                                     "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                                     "requires": {
-                                        "chalk": "2.1.0",
-                                        "source-map": "0.5.6",
-                                        "supports-color": "4.2.1"
+                                        "chalk": "^2.1.0",
+                                        "source-map": "^0.5.6",
+                                        "supports-color": "^4.2.1"
                                     },
                                     "dependencies": {
                                         "ansi-styles": {
@@ -15512,7 +15714,7 @@
                                             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                                             "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                                             "requires": {
-                                                "color-convert": "1.9.0"
+                                                "color-convert": "^1.9.0"
                                             }
                                         },
                                         "chalk": {
@@ -15520,9 +15722,9 @@
                                             "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
                                             "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                                             "requires": {
-                                                "ansi-styles": "3.2.0",
-                                                "escape-string-regexp": "1.0.5",
-                                                "supports-color": "4.2.1"
+                                                "ansi-styles": "^3.1.0",
+                                                "escape-string-regexp": "^1.0.5",
+                                                "supports-color": "^4.0.0"
                                             }
                                         },
                                         "color-convert": {
@@ -15530,7 +15732,7 @@
                                             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
                                             "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                                             "requires": {
-                                                "color-name": "1.1.3"
+                                                "color-name": "^1.1.1"
                                             }
                                         },
                                         "color-name": {
@@ -15558,7 +15760,7 @@
                                             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
                                             "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
                                             "requires": {
-                                                "has-flag": "2.0.0"
+                                                "has-flag": "^2.0.0"
                                             }
                                         }
                                     }
@@ -15567,343 +15769,395 @@
                                     "version": "https://registry.npmjs.org/postcss-parser-tests/-/postcss-parser-tests-6.0.2.tgz",
                                     "integrity": "sha1-Sm9kUAlcqMpXctQgzu7cfZP9CTk=",
                                     "requires": {
-                                        "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                                        "load-resources": "https://registry.npmjs.org/load-resources/-/load-resources-0.1.1.tgz"
+                                        "gulp-util": "^3.0.7",
+                                        "load-resources": "^0.1.1"
                                     }
                                 },
                                 "prelude-ls": {
-                                    "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                                    "version": "1.1.2",
+                                    "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                                     "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
                                 },
                                 "process-nextick-args": {
-                                    "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                                    "version": "1.0.7",
+                                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                                     "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                                 },
                                 "punycode": {
-                                    "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                                    "version": "1.4.1",
+                                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                                     "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                                 },
                                 "qs": {
-                                    "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                                    "version": "6.4.0",
+                                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
                                     "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
                                 },
                                 "readable-stream": {
-                                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                                    "version": "1.1.14",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                                     "requires": {
-                                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.1",
+                                        "isarray": "0.0.1",
+                                        "string_decoder": "~0.10.x"
                                     }
                                 },
                                 "repeat-string": {
-                                    "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                                    "version": "1.6.1",
+                                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                                     "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
                                 },
                                 "replace-ext": {
-                                    "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                                    "version": "0.0.1",
+                                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
                                     "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
                                 },
                                 "request": {
-                                    "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                                    "version": "2.81.0",
+                                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
                                     "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
                                     "requires": {
-                                        "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                                        "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                                        "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                                        "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                                        "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                                        "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                                        "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                                        "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                                        "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                                        "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                                        "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                                        "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                                        "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                                        "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                                        "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                                        "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                                        "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                                        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                                        "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                                        "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                                        "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                                        "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+                                        "aws-sign2": "~0.6.0",
+                                        "aws4": "^1.2.1",
+                                        "caseless": "~0.12.0",
+                                        "combined-stream": "~1.0.5",
+                                        "extend": "~3.0.0",
+                                        "forever-agent": "~0.6.1",
+                                        "form-data": "~2.1.1",
+                                        "har-validator": "~4.2.1",
+                                        "hawk": "~3.1.3",
+                                        "http-signature": "~1.1.0",
+                                        "is-typedarray": "~1.0.0",
+                                        "isstream": "~0.1.2",
+                                        "json-stringify-safe": "~5.0.1",
+                                        "mime-types": "~2.1.7",
+                                        "oauth-sign": "~0.8.1",
+                                        "performance-now": "^0.2.0",
+                                        "qs": "~6.4.0",
+                                        "safe-buffer": "^5.0.1",
+                                        "stringstream": "~0.0.4",
+                                        "tough-cookie": "~2.3.0",
+                                        "tunnel-agent": "^0.6.0",
+                                        "uuid": "^3.0.0"
                                     }
                                 },
                                 "resolve": {
-                                    "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                                    "version": "1.1.7",
+                                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                                     "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                                 },
                                 "right-align": {
-                                    "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                                    "version": "0.1.3",
+                                    "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                                     "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                                     "optional": true,
                                     "requires": {
-                                        "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+                                        "align-text": "^0.1.1"
                                     }
                                 },
                                 "safe-buffer": {
-                                    "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                                    "version": "5.1.1",
+                                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
                                     "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
                                 },
                                 "sntp": {
-                                    "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                                    "version": "1.0.9",
+                                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                                     "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                                     "requires": {
-                                        "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                        "hoek": "2.x.x"
                                     }
                                 },
                                 "source-map": {
-                                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                                    "version": "0.5.6",
+                                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                                     "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                                     "optional": true
                                 },
                                 "sparkles": {
-                                    "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                                     "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
                                 },
                                 "sprintf-js": {
-                                    "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                                    "version": "1.0.3",
+                                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                                     "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                                 },
                                 "sshpk": {
-                                    "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                                    "version": "1.13.1",
+                                    "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
                                     "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                                     "requires": {
-                                        "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                        "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                                        "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                                        "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                                        "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                                        "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                                        "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                        "asn1": "~0.2.3",
+                                        "assert-plus": "^1.0.0",
+                                        "bcrypt-pbkdf": "^1.0.0",
+                                        "dashdash": "^1.12.0",
+                                        "ecc-jsbn": "~0.1.1",
+                                        "getpass": "^0.1.1",
+                                        "jsbn": "~0.1.0",
+                                        "tweetnacl": "~0.14.0"
                                     },
                                     "dependencies": {
                                         "assert-plus": {
-                                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                         }
                                     }
                                 },
                                 "string_decoder": {
-                                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                    "version": "0.10.31",
+                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                                 },
                                 "stringstream": {
-                                    "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                                    "version": "0.0.5",
+                                    "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                                     "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
                                 },
                                 "strip-ansi": {
-                                    "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                    "version": "3.0.1",
+                                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                                     "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                                     "requires": {
-                                        "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                        "ansi-regex": "^2.0.0"
                                     }
                                 },
                                 "supports-color": {
-                                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                                    "version": "3.1.2",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                                     "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                                     "requires": {
-                                        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                                        "has-flag": "^1.0.0"
                                     }
                                 },
                                 "through2": {
-                                    "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                                    "version": "2.0.3",
+                                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
                                     "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                                     "requires": {
-                                        "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                                        "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                                        "readable-stream": "^2.1.5",
+                                        "xtend": "~4.0.1"
                                     },
                                     "dependencies": {
                                         "isarray": {
-                                            "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                            "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                             "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                                         },
                                         "readable-stream": {
-                                            "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                                            "version": "2.3.3",
+                                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                                             "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
                                             "requires": {
-                                                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                                "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                                "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                                                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                                                "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                                "core-util-is": "~1.0.0",
+                                                "inherits": "~2.0.3",
+                                                "isarray": "~1.0.0",
+                                                "process-nextick-args": "~1.0.6",
+                                                "safe-buffer": "~5.1.1",
+                                                "string_decoder": "~1.0.3",
+                                                "util-deprecate": "~1.0.1"
                                             }
                                         },
                                         "string_decoder": {
-                                            "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                                            "version": "1.0.3",
+                                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                                             "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                                             "requires": {
-                                                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                                "safe-buffer": "~5.1.0"
                                             }
                                         }
                                     }
                                 },
                                 "time-stamp": {
-                                    "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+                                    "version": "1.1.0",
+                                    "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
                                     "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
                                 },
                                 "tough-cookie": {
-                                    "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                                    "version": "2.3.2",
+                                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                                     "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                                     "requires": {
-                                        "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                                        "punycode": "^1.4.1"
                                     }
                                 },
                                 "tunnel-agent": {
-                                    "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                                    "version": "0.6.0",
+                                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                                     "requires": {
-                                        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                        "safe-buffer": "^5.0.1"
                                     }
                                 },
                                 "tweetnacl": {
-                                    "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                                    "version": "0.14.5",
+                                    "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                                     "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                                     "optional": true
                                 },
                                 "type-check": {
-                                    "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                                    "version": "0.3.2",
+                                    "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                                     "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                                     "requires": {
-                                        "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                                        "prelude-ls": "~1.1.2"
                                     }
                                 },
                                 "type-detect": {
-                                    "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
                                     "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
                                 },
                                 "uglify-js": {
-                                    "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+                                    "version": "2.7.5",
+                                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
                                     "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
                                     "optional": true,
                                     "requires": {
-                                        "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                                        "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                                        "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                                        "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+                                        "async": "~0.2.6",
+                                        "source-map": "~0.5.1",
+                                        "uglify-to-browserify": "~1.0.0",
+                                        "yargs": "~3.10.0"
                                     },
                                     "dependencies": {
                                         "async": {
-                                            "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                                            "version": "0.2.10",
+                                            "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                                             "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
                                             "optional": true
                                         }
                                     }
                                 },
                                 "uglify-to-browserify": {
-                                    "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                                     "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                                     "optional": true
                                 },
                                 "util-deprecate": {
-                                    "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                                     "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                                 },
                                 "uuid": {
-                                    "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
                                     "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
                                 },
                                 "verror": {
-                                    "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                                    "version": "1.10.0",
+                                    "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
                                     "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                                     "requires": {
-                                        "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                        "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+                                        "assert-plus": "^1.0.0",
+                                        "core-util-is": "1.0.2",
+                                        "extsprintf": "^1.2.0"
                                     },
                                     "dependencies": {
                                         "assert-plus": {
-                                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                            "version": "1.0.0",
+                                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                         }
                                     }
                                 },
                                 "vinyl": {
-                                    "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+                                    "version": "0.5.3",
+                                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                                     "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                                     "requires": {
-                                        "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                                        "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                                        "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                        "clone": "^1.0.0",
+                                        "clone-stats": "^0.0.1",
+                                        "replace-ext": "0.0.1"
                                     }
                                 },
                                 "which": {
-                                    "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+                                    "version": "1.2.12",
+                                    "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
                                     "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
                                     "requires": {
-                                        "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                                        "isexe": "^1.1.1"
                                     }
                                 },
                                 "window-size": {
-                                    "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                                    "version": "0.1.0",
+                                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                                     "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                                     "optional": true
                                 },
                                 "wordwrap": {
-                                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                                     "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
                                 },
                                 "wrappy": {
-                                    "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                    "version": "1.0.2",
+                                    "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                                     "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                                 },
                                 "xtend": {
-                                    "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                                    "version": "4.0.1",
+                                    "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                                     "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                                 },
                                 "yargs": {
-                                    "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                                    "version": "3.10.0",
+                                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                                     "optional": true,
                                     "requires": {
-                                        "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                                        "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                                        "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                                        "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                                        "camelcase": "^1.0.2",
+                                        "cliui": "^2.1.0",
+                                        "decamelize": "^1.0.0",
+                                        "window-size": "0.1.0"
                                     }
                                 }
                             }
                         },
                         "prelude-ls": {
-                            "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
                         },
                         "repeat-string": {
-                            "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                            "version": "1.6.1",
+                            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
                         },
                         "resolve": {
-                            "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                            "version": "1.1.7",
+                            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                         },
                         "right-align": {
-                            "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                             "optional": true,
                             "requires": {
-                                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+                                "align-text": "^0.1.1"
                             }
                         },
                         "source-map": {
-                            "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                            "version": "0.5.6",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                             "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
                         },
                         "sprintf-js": {
-                            "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                         },
                         "supports-color": {
-                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                             "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                             "requires": {
-                                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                                "has-flag": "^1.0.0"
                             }
                         },
                         "tinycolor2": {
@@ -15912,10 +16166,11 @@
                             "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
                         },
                         "type-check": {
-                            "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                            "version": "0.3.2",
+                            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                             "requires": {
-                                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                                "prelude-ls": "~1.1.2"
                             }
                         },
                         "type-detect": {
@@ -15924,57 +16179,65 @@
                             "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo="
                         },
                         "uglify-js": {
-                            "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+                            "version": "2.7.5",
+                            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
                             "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
                             "optional": true,
                             "requires": {
-                                "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+                                "async": "~0.2.6",
+                                "source-map": "~0.5.1",
+                                "uglify-to-browserify": "~1.0.0",
+                                "yargs": "~3.10.0"
                             },
                             "dependencies": {
                                 "async": {
-                                    "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                                    "version": "0.2.10",
+                                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                                     "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
                                     "optional": true
                                 }
                             }
                         },
                         "uglify-to-browserify": {
-                            "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                             "optional": true
                         },
                         "which": {
-                            "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+                            "version": "1.2.12",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
                             "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
                             "requires": {
-                                "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                                "isexe": "^1.1.1"
                             }
                         },
                         "window-size": {
-                            "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                             "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                             "optional": true
                         },
                         "wordwrap": {
-                            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
                         },
                         "wrappy": {
-                            "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                         },
                         "yargs": {
-                            "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "version": "3.10.0",
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "optional": true,
                             "requires": {
-                                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
+                                "window-size": "0.1.0"
                             }
                         }
                     }
@@ -15984,852 +16247,987 @@
                     "resolved": "https://registry.npmjs.org/postcss-wee-syntax/-/postcss-wee-syntax-3.0.0.tgz",
                     "integrity": "sha512-FNhQGct9M/d4VeT0997SDfKW51c5b7CMAgsR04zJgRVbTFHOCbAwps1gtxqNVbGW6GRDqfDIjrMBqQDkcCySQw==",
                     "requires": {
-                        "postcss": "6.0.9"
+                        "postcss": "^6.0.9"
                     },
                     "dependencies": {
                         "abbrev": {
-                            "version": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
+                            "version": "1.0.9",
+                            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
                             "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
                         },
                         "ajv": {
-                            "version": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                            "version": "4.11.8",
+                            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
                             "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                             "requires": {
-                                "co": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-                                "json-stable-stringify": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+                                "co": "^4.6.0",
+                                "json-stable-stringify": "^1.0.1"
                             }
                         },
                         "align-text": {
-                            "version": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                            "version": "0.1.4",
+                            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
                             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
                             "requires": {
-                                "kind-of": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
-                                "longest": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-                                "repeat-string": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                "kind-of": "^3.0.2",
+                                "longest": "^1.0.1",
+                                "repeat-string": "^1.5.2"
                             }
                         },
                         "amdefine": {
-                            "version": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
                             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
                         },
                         "ansi-regex": {
-                            "version": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
                             "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
                         },
                         "ansi-styles": {
-                            "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                             "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
                             "requires": {
-                                "color-convert": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+                                "color-convert": "^1.9.0"
                             }
                         },
                         "argparse": {
-                            "version": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                            "version": "1.0.9",
+                            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
                             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
                             "requires": {
-                                "sprintf-js": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                                "sprintf-js": "~1.0.2"
                             }
                         },
                         "array-differ": {
-                            "version": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
                             "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE="
                         },
                         "array-uniq": {
-                            "version": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
                             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
                         },
                         "asn1": {
-                            "version": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                            "version": "0.2.3",
+                            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                             "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                         },
                         "assert-plus": {
-                            "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
                             "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
                         },
                         "assertion-error": {
-                            "version": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
                             "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw="
                         },
                         "async": {
-                            "version": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                            "version": "1.5.2",
+                            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
                             "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
                         },
                         "asynckit": {
-                            "version": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                            "version": "0.4.0",
+                            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
                             "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                         },
                         "aws-sign2": {
-                            "version": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
                             "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
                         },
                         "aws4": {
-                            "version": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+                            "version": "1.6.0",
+                            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
                             "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
                         },
                         "balanced-match": {
-                            "version": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                            "version": "0.4.2",
+                            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
                             "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg="
                         },
                         "bcrypt-pbkdf": {
-                            "version": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
                             "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
                             "optional": true,
                             "requires": {
-                                "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                "tweetnacl": "^0.14.3"
                             }
                         },
                         "beeper": {
-                            "version": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
                             "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
                         },
                         "boom": {
-                            "version": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                            "version": "2.10.1",
+                            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
                             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
                             "requires": {
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                "hoek": "2.x.x"
                             }
                         },
                         "brace-expansion": {
-                            "version": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                            "version": "1.1.6",
+                            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                             "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                             "requires": {
-                                "balanced-match": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
-                                "concat-map": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                "balanced-match": "^0.4.1",
+                                "concat-map": "0.0.1"
                             }
                         },
                         "browser-stdout": {
-                            "version": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
                             "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8="
                         },
                         "camelcase": {
-                            "version": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+                            "version": "1.2.1",
+                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                             "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
                             "optional": true
                         },
                         "caseless": {
-                            "version": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+                            "version": "0.12.0",
+                            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
                             "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
                         },
                         "center-align": {
-                            "version": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
                             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
                             "optional": true,
                             "requires": {
-                                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                                "lazy-cache": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                                "align-text": "^0.1.3",
+                                "lazy-cache": "^1.0.3"
                             }
                         },
                         "chai": {
                             "version": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
                             "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
                             "requires": {
-                                "assertion-error": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
-                                "deep-eql": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-                                "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+                                "assertion-error": "^1.0.1",
+                                "deep-eql": "^0.1.3",
+                                "type-detect": "^1.0.0"
                             }
                         },
                         "chalk": {
                             "version": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
                             "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
                             "requires": {
-                                "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+                                "ansi-styles": "^3.1.0",
+                                "escape-string-regexp": "^1.0.5",
+                                "supports-color": "^4.0.0"
                             },
                             "dependencies": {
                                 "has-flag": {
-                                    "version": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
                                     "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
                                 },
                                 "supports-color": {
-                                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                                    "version": "4.2.1",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
                                     "integrity": "sha1-ZaS7JjHpDgJCDbpVVMN1pHVLuDY=",
                                     "requires": {
-                                        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                                        "has-flag": "^2.0.0"
                                     }
                                 }
                             }
                         },
                         "cliui": {
-                            "version": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                            "version": "2.1.0",
+                            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
                             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
                             "optional": true,
                             "requires": {
-                                "center-align": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                                "right-align": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                                "center-align": "^0.1.1",
+                                "right-align": "^0.1.1",
+                                "wordwrap": "0.0.2"
                             },
                             "dependencies": {
                                 "wordwrap": {
-                                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                                    "version": "0.0.2",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
                                     "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
                                     "optional": true
                                 }
                             }
                         },
                         "clone": {
-                            "version": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
                             "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk="
                         },
                         "clone-stats": {
-                            "version": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                             "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE="
                         },
                         "co": {
-                            "version": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                            "version": "4.6.0",
+                            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
                             "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
                         },
                         "color-convert": {
-                            "version": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                            "version": "1.9.0",
+                            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
                             "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                             "requires": {
-                                "color-name": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                                "color-name": "^1.1.1"
                             }
                         },
                         "color-name": {
-                            "version": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                            "version": "1.1.3",
+                            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
                             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
                         },
                         "combined-stream": {
-                            "version": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
                             "requires": {
-                                "delayed-stream": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                                "delayed-stream": "~1.0.0"
                             }
                         },
                         "commander": {
-                            "version": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                            "version": "2.9.0",
+                            "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
                             "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
                             "requires": {
-                                "graceful-readlink": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                                "graceful-readlink": ">= 1.0.0"
                             }
                         },
                         "concat-map": {
-                            "version": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
                         },
                         "core-util-is": {
-                            "version": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                             "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                         },
                         "cryptiles": {
-                            "version": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                            "version": "2.0.5",
+                            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
                             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
                             "requires": {
-                                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                                "boom": "2.x.x"
                             }
                         },
                         "dashdash": {
-                            "version": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                            "version": "1.14.1",
+                            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
                             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
                             "requires": {
-                                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                "assert-plus": "^1.0.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                 }
                             }
                         },
                         "dateformat": {
-                            "version": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
                             "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
                         },
                         "debug": {
-                            "version": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                            "version": "2.6.8",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
                             "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
                             "requires": {
-                                "ms": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                                "ms": "2.0.0"
                             }
                         },
                         "decamelize": {
-                            "version": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
                             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
                             "optional": true
                         },
                         "deep-eql": {
-                            "version": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
                             "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
                             "requires": {
-                                "type-detect": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+                                "type-detect": "0.1.1"
                             },
                             "dependencies": {
                                 "type-detect": {
-                                    "version": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+                                    "version": "0.1.1",
+                                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
                                     "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
                                 }
                             }
                         },
                         "deep-is": {
-                            "version": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
                             "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
                         },
                         "delayed-stream": {
-                            "version": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
                             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                         },
                         "diff": {
-                            "version": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
                             "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k="
                         },
                         "duplexer2": {
-                            "version": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                            "version": "0.0.2",
+                            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
                             "requires": {
-                                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+                                "readable-stream": "~1.1.9"
                             }
                         },
                         "ecc-jsbn": {
-                            "version": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                             "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
                             "optional": true,
                             "requires": {
-                                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                                "jsbn": "~0.1.0"
                             }
                         },
                         "escape-string-regexp": {
-                            "version": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
                             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                         },
                         "escodegen": {
-                            "version": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+                            "version": "1.8.1",
+                            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
                             "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
                             "requires": {
-                                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                                "estraverse": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-                                "esutils": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-                                "optionator": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+                                "esprima": "^2.7.1",
+                                "estraverse": "^1.9.1",
+                                "esutils": "^2.0.2",
+                                "optionator": "^0.8.1",
+                                "source-map": "~0.2.0"
                             },
                             "dependencies": {
                                 "source-map": {
-                                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                                    "version": "0.2.0",
+                                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
                                     "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
                                     "optional": true,
                                     "requires": {
-                                        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                                        "amdefine": ">=0.0.4"
                                     }
                                 }
                             }
                         },
                         "esprima": {
-                            "version": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
+                            "version": "2.7.3",
+                            "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
                             "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
                         },
                         "estraverse": {
-                            "version": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                            "version": "1.9.3",
+                            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
                             "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
                         },
                         "esutils": {
-                            "version": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+                            "version": "2.0.2",
+                            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
                             "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
                         },
                         "extend": {
-                            "version": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
                             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
                         },
                         "extsprintf": {
-                            "version": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
                             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
                         },
                         "fancy-log": {
-                            "version": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+                            "version": "1.3.0",
+                            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
                             "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
                             "requires": {
-                                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                "time-stamp": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz"
+                                "chalk": "^1.1.1",
+                                "time-stamp": "^1.0.0"
                             },
                             "dependencies": {
                                 "ansi-styles": {
-                                    "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                    "version": "2.2.1",
+                                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                     "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
                                 },
                                 "chalk": {
-                                    "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                    "version": "1.1.3",
+                                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                                     "requires": {
-                                        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                        "ansi-styles": "^2.2.1",
+                                        "escape-string-regexp": "^1.0.2",
+                                        "has-ansi": "^2.0.0",
+                                        "strip-ansi": "^3.0.0",
+                                        "supports-color": "^2.0.0"
                                     }
                                 },
                                 "supports-color": {
-                                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                             }
                         },
                         "fast-levenshtein": {
-                            "version": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+                            "version": "2.0.6",
+                            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
                             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
                         },
                         "forever-agent": {
-                            "version": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
                             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
                         },
                         "form-data": {
-                            "version": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+                            "version": "2.1.4",
+                            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
                             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                             "requires": {
-                                "asynckit": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-                                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
+                                "asynckit": "^0.4.0",
+                                "combined-stream": "^1.0.5",
+                                "mime-types": "^2.1.12"
                             }
                         },
                         "fs.realpath": {
-                            "version": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
                             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
                         },
                         "getpass": {
-                            "version": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                            "version": "0.1.7",
+                            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
                             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
                             "requires": {
-                                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                                "assert-plus": "^1.0.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                 }
                             }
                         },
                         "glob": {
-                            "version": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                            "version": "5.0.15",
+                            "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
                             "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                             "requires": {
-                                "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                "inflight": "^1.0.4",
+                                "inherits": "2",
+                                "minimatch": "2 || 3",
+                                "once": "^1.3.0",
+                                "path-is-absolute": "^1.0.0"
                             }
                         },
                         "glogg": {
-                            "version": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
                             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
                             "requires": {
-                                "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                                "sparkles": "^1.0.0"
                             }
                         },
                         "graceful-readlink": {
-                            "version": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
                             "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
                         },
                         "growl": {
-                            "version": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+                            "version": "1.9.2",
+                            "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
                             "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8="
                         },
                         "gulp-util": {
-                            "version": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+                            "version": "3.0.8",
+                            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
                             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
                             "requires": {
-                                "array-differ": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-                                "array-uniq": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-                                "beeper": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-                                "chalk": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                "dateformat": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-                                "fancy-log": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-                                "gulplog": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-                                "has-gulplog": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-                                "lodash._reescape": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-                                "lodash._reevaluate": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-                                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                                "lodash.template": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-                                "minimist": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                                "multipipe": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-                                "object-assign": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                                "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                                "through2": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-                                "vinyl": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz"
+                                "array-differ": "^1.0.0",
+                                "array-uniq": "^1.0.2",
+                                "beeper": "^1.0.0",
+                                "chalk": "^1.0.0",
+                                "dateformat": "^2.0.0",
+                                "fancy-log": "^1.1.0",
+                                "gulplog": "^1.0.0",
+                                "has-gulplog": "^0.1.0",
+                                "lodash._reescape": "^3.0.0",
+                                "lodash._reevaluate": "^3.0.0",
+                                "lodash._reinterpolate": "^3.0.0",
+                                "lodash.template": "^3.0.0",
+                                "minimist": "^1.1.0",
+                                "multipipe": "^0.1.2",
+                                "object-assign": "^3.0.0",
+                                "replace-ext": "0.0.1",
+                                "through2": "^2.0.0",
+                                "vinyl": "^0.5.0"
                             },
                             "dependencies": {
                                 "ansi-styles": {
-                                    "version": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                                    "version": "2.2.1",
+                                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
                                     "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
                                 },
                                 "chalk": {
-                                    "version": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                    "version": "1.1.3",
+                                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
                                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                                     "requires": {
-                                        "ansi-styles": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-                                        "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                        "has-ansi": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                        "strip-ansi": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                        "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                        "ansi-styles": "^2.2.1",
+                                        "escape-string-regexp": "^1.0.2",
+                                        "has-ansi": "^2.0.0",
+                                        "strip-ansi": "^3.0.0",
+                                        "supports-color": "^2.0.0"
                                     }
                                 },
                                 "supports-color": {
-                                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                                    "version": "2.0.0",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                                 }
                             }
                         },
                         "gulplog": {
-                            "version": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
                             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
                             "requires": {
-                                "glogg": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz"
+                                "glogg": "^1.0.0"
                             }
                         },
                         "handlebars": {
-                            "version": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+                            "version": "4.0.6",
+                            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
                             "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
                             "requires": {
-                                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                                "optimist": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                                "uglify-js": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz"
+                                "async": "^1.4.0",
+                                "optimist": "^0.6.1",
+                                "source-map": "^0.4.4",
+                                "uglify-js": "^2.6"
                             },
                             "dependencies": {
                                 "source-map": {
-                                    "version": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                                    "version": "0.4.4",
+                                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
                                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                                     "requires": {
-                                        "amdefine": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                                        "amdefine": ">=0.0.4"
                                     }
                                 }
                             }
                         },
                         "har-schema": {
-                            "version": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                            "version": "1.0.5",
+                            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
                             "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
                         },
                         "har-validator": {
-                            "version": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+                            "version": "4.2.1",
+                            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
                             "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                             "requires": {
-                                "ajv": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                                "har-schema": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                                "ajv": "^4.9.1",
+                                "har-schema": "^1.0.5"
                             }
                         },
                         "has-ansi": {
-                            "version": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
                             "requires": {
-                                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                "ansi-regex": "^2.0.0"
                             }
                         },
                         "has-flag": {
-                            "version": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
                             "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
                         },
                         "has-gulplog": {
-                            "version": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
                             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
                             "requires": {
-                                "sparkles": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz"
+                                "sparkles": "^1.0.0"
                             }
                         },
                         "hawk": {
-                            "version": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+                            "version": "3.1.3",
+                            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
                             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
                             "requires": {
-                                "boom": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-                                "cryptiles": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-                                "sntp": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                                "boom": "2.x.x",
+                                "cryptiles": "2.x.x",
+                                "hoek": "2.x.x",
+                                "sntp": "1.x.x"
                             }
                         },
                         "hoek": {
-                            "version": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                            "version": "2.16.3",
+                            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
                             "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                         },
                         "http-signature": {
-                            "version": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+                            "version": "1.1.1",
+                            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
                             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                             "requires": {
-                                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                                "jsprim": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-                                "sshpk": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+                                "assert-plus": "^0.2.0",
+                                "jsprim": "^1.2.2",
+                                "sshpk": "^1.7.0"
                             }
                         },
                         "inflight": {
-                            "version": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                            "version": "1.0.6",
+                            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                             "requires": {
-                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                "once": "^1.3.0",
+                                "wrappy": "1"
                             }
                         },
                         "inherits": {
-                            "version": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
                             "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                         },
                         "is-buffer": {
-                            "version": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz",
                             "integrity": "sha1-z8hszV3FpS+oBIkRHGkgxFfi2Ys="
                         },
                         "is-typedarray": {
-                            "version": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
                             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
                         },
                         "isarray": {
-                            "version": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                             "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                         },
                         "isexe": {
-                            "version": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz",
                             "integrity": "sha1-NvPiLmB1CSD15yQaR2qMakInWtA="
                         },
                         "isstream": {
-                            "version": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                            "version": "0.1.2",
+                            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
                             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
                         },
                         "istanbul": {
                             "version": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.5.tgz",
                             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
                             "requires": {
-                                "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",
-                                "async": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-                                "escodegen": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-                                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-                                "glob": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                                "handlebars": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
-                                "js-yaml": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-                                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                                "nopt": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-                                "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                "resolve": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-                                "which": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                                "abbrev": "1.0.x",
+                                "async": "1.x",
+                                "escodegen": "1.8.x",
+                                "esprima": "2.7.x",
+                                "glob": "^5.0.15",
+                                "handlebars": "^4.0.1",
+                                "js-yaml": "3.x",
+                                "mkdirp": "0.5.x",
+                                "nopt": "3.x",
+                                "once": "1.x",
+                                "resolve": "1.1.x",
+                                "supports-color": "^3.1.0",
+                                "which": "^1.1.1",
+                                "wordwrap": "^1.0.0"
                             },
                             "dependencies": {
                                 "supports-color": {
-                                    "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                                    "version": "3.2.3",
+                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
                                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                                     "requires": {
-                                        "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                                        "has-flag": "^1.0.0"
                                     }
                                 }
                             }
                         },
                         "js-yaml": {
-                            "version": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                            "version": "3.7.0",
+                            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
                             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
                             "requires": {
-                                "argparse": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                                "esprima": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+                                "argparse": "^1.0.7",
+                                "esprima": "^2.6.0"
                             }
                         },
                         "jsbn": {
-                            "version": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
                             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                             "optional": true
                         },
                         "json-schema": {
-                            "version": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                            "version": "0.2.3",
+                            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                             "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                         },
                         "json-stable-stringify": {
-                            "version": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
                             "requires": {
-                                "jsonify": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                                "jsonify": "~0.0.0"
                             }
                         },
                         "json-stringify-safe": {
-                            "version": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                            "version": "5.0.1",
+                            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
                             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
                         },
                         "json3": {
-                            "version": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+                            "version": "3.3.2",
+                            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
                             "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE="
                         },
                         "jsonify": {
-                            "version": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                            "version": "0.0.0",
+                            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
                             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
                         },
                         "jsprim": {
-                            "version": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+                            "version": "1.4.1",
+                            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
                             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
                             "requires": {
-                                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-                                "json-schema": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-                                "verror": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+                                "assert-plus": "1.0.0",
+                                "extsprintf": "1.3.0",
+                                "json-schema": "0.2.3",
+                                "verror": "1.10.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                 }
                             }
                         },
                         "kind-of": {
-                            "version": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.1.0.tgz",
                             "integrity": "sha1-R11pil5J/15T0U4+cyQp3Iv0z0c=",
                             "requires": {
-                                "is-buffer": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.4.tgz"
+                                "is-buffer": "^1.0.2"
                             }
                         },
                         "lazy-cache": {
-                            "version": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+                            "version": "1.0.4",
+                            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
                             "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
                             "optional": true
                         },
                         "levn": {
-                            "version": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+                            "version": "0.3.0",
+                            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
                             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
                             "requires": {
-                                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2"
                             }
                         },
                         "load-resources": {
-                            "version": "https://registry.npmjs.org/load-resources/-/load-resources-0.1.1.tgz",
+                            "version": "0.1.1",
+                            "resolved": "https://registry.npmjs.org/load-resources/-/load-resources-0.1.1.tgz",
                             "integrity": "sha1-PFiPn7v5lnmS8+EVfcUk8gI+Fm4=",
                             "requires": {
-                                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                "request": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+                                "escape-string-regexp": "^1.0.3",
+                                "request": "^2.55.0"
                             }
                         },
                         "lodash._baseassign": {
-                            "version": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
                             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
                             "requires": {
-                                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+                                "lodash._basecopy": "^3.0.0",
+                                "lodash.keys": "^3.0.0"
                             }
                         },
                         "lodash._basecopy": {
-                            "version": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
                             "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY="
                         },
                         "lodash._basecreate": {
-                            "version": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+                            "version": "3.0.3",
+                            "resolved": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
                             "integrity": "sha1-G8ZhYU2qf8MRt9A78WgGoCE8+CE="
                         },
                         "lodash._basetostring": {
-                            "version": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
                             "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U="
                         },
                         "lodash._basevalues": {
-                            "version": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
                             "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc="
                         },
                         "lodash._getnative": {
-                            "version": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+                            "version": "3.9.1",
+                            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
                             "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
                         },
                         "lodash._isiterateecall": {
-                            "version": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+                            "version": "3.0.9",
+                            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
                             "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw="
                         },
                         "lodash._reescape": {
-                            "version": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
                             "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo="
                         },
                         "lodash._reevaluate": {
-                            "version": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
                             "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0="
                         },
                         "lodash._reinterpolate": {
-                            "version": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
                             "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
                         },
                         "lodash._root": {
-                            "version": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
                             "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
                         },
                         "lodash.create": {
-                            "version": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+                            "version": "3.1.1",
+                            "resolved": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
                             "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
                             "requires": {
-                                "lodash._baseassign": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                                "lodash._basecreate": "https://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
-                                "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                                "lodash._baseassign": "^3.0.0",
+                                "lodash._basecreate": "^3.0.0",
+                                "lodash._isiterateecall": "^3.0.0"
                             }
                         },
                         "lodash.escape": {
-                            "version": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+                            "version": "3.2.0",
+                            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
                             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
                             "requires": {
-                                "lodash._root": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                                "lodash._root": "^3.0.0"
                             }
                         },
                         "lodash.isarguments": {
-                            "version": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
                             "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo="
                         },
                         "lodash.isarray": {
-                            "version": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+                            "version": "3.0.4",
+                            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
                             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
                         },
                         "lodash.keys": {
-                            "version": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
                             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
                             "requires": {
-                                "lodash._getnative": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-                                "lodash.isarguments": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-                                "lodash.isarray": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                                "lodash._getnative": "^3.0.0",
+                                "lodash.isarguments": "^3.0.0",
+                                "lodash.isarray": "^3.0.0"
                             }
                         },
                         "lodash.restparam": {
-                            "version": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                            "version": "3.6.1",
+                            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
                             "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
                         },
                         "lodash.template": {
-                            "version": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+                            "version": "3.6.2",
+                            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
                             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
                             "requires": {
-                                "lodash._basecopy": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-                                "lodash._basetostring": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-                                "lodash._basevalues": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-                                "lodash._isiterateecall": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-                                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                                "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-                                "lodash.keys": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                                "lodash.restparam": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-                                "lodash.templatesettings": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz"
+                                "lodash._basecopy": "^3.0.0",
+                                "lodash._basetostring": "^3.0.0",
+                                "lodash._basevalues": "^3.0.0",
+                                "lodash._isiterateecall": "^3.0.0",
+                                "lodash._reinterpolate": "^3.0.0",
+                                "lodash.escape": "^3.0.0",
+                                "lodash.keys": "^3.0.0",
+                                "lodash.restparam": "^3.0.0",
+                                "lodash.templatesettings": "^3.0.0"
                             }
                         },
                         "lodash.templatesettings": {
-                            "version": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+                            "version": "3.1.1",
+                            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
                             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
                             "requires": {
-                                "lodash._reinterpolate": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-                                "lodash.escape": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz"
+                                "lodash._reinterpolate": "^3.0.0",
+                                "lodash.escape": "^3.0.0"
                             }
                         },
                         "longest": {
-                            "version": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
                             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
                         },
                         "mime-db": {
-                            "version": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+                            "version": "1.29.0",
+                            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
                             "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
                         },
                         "mime-types": {
-                            "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                            "version": "2.1.16",
+                            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
                             "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
                             "requires": {
-                                "mime-db": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                                "mime-db": "~1.29.0"
                             }
                         },
                         "minimatch": {
-                            "version": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                            "version": "3.0.3",
+                            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                             "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                             "requires": {
-                                "brace-expansion": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz"
+                                "brace-expansion": "^1.0.0"
                             }
                         },
                         "minimist": {
-                            "version": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                            "version": "1.2.0",
+                            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                         },
                         "mkdirp": {
-                            "version": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                            "version": "0.5.1",
+                            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                             "requires": {
-                                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                                "minimist": "0.0.8"
                             },
                             "dependencies": {
                                 "minimist": {
-                                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                                    "version": "0.0.8",
+                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                                     "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
                                 }
                             }
@@ -16838,102 +17236,115 @@
                             "version": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
                             "integrity": "sha1-EyhWfScX+ZcDD4AGI0vOm4zXJGU=",
                             "requires": {
-                                "browser-stdout": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
-                                "commander": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                                "debug": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                                "diff": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
-                                "escape-string-regexp": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-                                "glob": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-                                "growl": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-                                "json3": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
-                                "lodash.create": "https://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-                                "mkdirp": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                                "supports-color": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+                                "browser-stdout": "1.3.0",
+                                "commander": "2.9.0",
+                                "debug": "2.6.8",
+                                "diff": "3.2.0",
+                                "escape-string-regexp": "1.0.5",
+                                "glob": "7.1.1",
+                                "growl": "1.9.2",
+                                "json3": "3.3.2",
+                                "lodash.create": "3.1.1",
+                                "mkdirp": "0.5.1",
+                                "supports-color": "3.1.2"
                             },
                             "dependencies": {
                                 "glob": {
-                                    "version": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+                                    "version": "7.1.1",
+                                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
                                     "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
                                     "requires": {
-                                        "fs.realpath": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-                                        "inflight": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-                                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                        "minimatch": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
-                                        "once": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                                        "path-is-absolute": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                                        "fs.realpath": "^1.0.0",
+                                        "inflight": "^1.0.4",
+                                        "inherits": "2",
+                                        "minimatch": "^3.0.2",
+                                        "once": "^1.3.0",
+                                        "path-is-absolute": "^1.0.0"
                                     }
                                 }
                             }
                         },
                         "ms": {
-                            "version": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                         },
                         "multipipe": {
-                            "version": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                            "version": "0.1.2",
+                            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
                             "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
                             "requires": {
-                                "duplexer2": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz"
+                                "duplexer2": "0.0.2"
                             }
                         },
                         "nopt": {
-                            "version": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+                            "version": "3.0.6",
+                            "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
                             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
                             "requires": {
-                                "abbrev": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz"
+                                "abbrev": "1"
                             }
                         },
                         "oauth-sign": {
-                            "version": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                            "version": "0.8.2",
+                            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
                             "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
                         },
                         "object-assign": {
-                            "version": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                             "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
                         },
                         "once": {
-                            "version": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                            "version": "1.4.0",
+                            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
                             "requires": {
-                                "wrappy": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                "wrappy": "1"
                             }
                         },
                         "optimist": {
-                            "version": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
                             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
                             "requires": {
-                                "minimist": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                                "minimist": "~0.0.1",
+                                "wordwrap": "~0.0.2"
                             },
                             "dependencies": {
                                 "minimist": {
-                                    "version": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                                    "version": "0.0.10",
+                                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
                                     "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
                                 },
                                 "wordwrap": {
-                                    "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                                    "version": "0.0.3",
+                                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
                                     "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
                                 }
                             }
                         },
                         "optionator": {
-                            "version": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+                            "version": "0.8.2",
+                            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
                             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
                             "requires": {
-                                "deep-is": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-                                "fast-levenshtein": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-                                "levn": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-                                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-                                "type-check": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-                                "wordwrap": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                                "deep-is": "~0.1.3",
+                                "fast-levenshtein": "~2.0.4",
+                                "levn": "~0.3.0",
+                                "prelude-ls": "~1.1.2",
+                                "type-check": "~0.3.2",
+                                "wordwrap": "~1.0.0"
                             }
                         },
                         "path-is-absolute": {
-                            "version": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                            "version": "1.0.1",
+                            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
                             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
                         },
                         "performance-now": {
-                            "version": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+                            "version": "0.2.0",
+                            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
                             "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
                         },
                         "postcss": {
@@ -16941,9 +17352,9 @@
                             "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.9.tgz",
                             "integrity": "sha512-bBE2AHNEBhF23TfET6AA/lFP8ah+qHOZoFJEflFG+HgvVLdTmMOrocx/4LVVDIn3w6jUssw1q2Exk1cc9UOI8w==",
                             "requires": {
-                                "chalk": "2.1.0",
-                                "source-map": "0.5.6",
-                                "supports-color": "4.2.1"
+                                "chalk": "^2.1.0",
+                                "source-map": "^0.5.6",
+                                "supports-color": "^4.2.1"
                             },
                             "dependencies": {
                                 "ansi-styles": {
@@ -16951,7 +17362,7 @@
                                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
                                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                                     "requires": {
-                                        "color-convert": "1.9.0"
+                                        "color-convert": "^1.9.0"
                                     }
                                 },
                                 "chalk": {
@@ -16959,9 +17370,9 @@
                                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
                                     "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
                                     "requires": {
-                                        "ansi-styles": "3.2.0",
-                                        "escape-string-regexp": "1.0.5",
-                                        "supports-color": "4.2.1"
+                                        "ansi-styles": "^3.1.0",
+                                        "escape-string-regexp": "^1.0.5",
+                                        "supports-color": "^4.0.0"
                                     }
                                 },
                                 "color-convert": {
@@ -16969,7 +17380,7 @@
                                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
                                     "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
                                     "requires": {
-                                        "color-name": "1.1.3"
+                                        "color-name": "^1.1.1"
                                     }
                                 },
                                 "color-name": {
@@ -16997,7 +17408,7 @@
                                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
                                     "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
                                     "requires": {
-                                        "has-flag": "2.0.0"
+                                        "has-flag": "^2.0.0"
                                     }
                                 }
                             }
@@ -17006,306 +17417,351 @@
                             "version": "https://registry.npmjs.org/postcss-parser-tests/-/postcss-parser-tests-6.0.2.tgz",
                             "integrity": "sha1-Sm9kUAlcqMpXctQgzu7cfZP9CTk=",
                             "requires": {
-                                "gulp-util": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-                                "load-resources": "https://registry.npmjs.org/load-resources/-/load-resources-0.1.1.tgz"
+                                "gulp-util": "^3.0.7",
+                                "load-resources": "^0.1.1"
                             }
                         },
                         "prelude-ls": {
-                            "version": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                            "version": "1.1.2",
+                            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
                             "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
                         },
                         "process-nextick-args": {
-                            "version": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                            "version": "1.0.7",
+                            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                             "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                         },
                         "punycode": {
-                            "version": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                            "version": "1.4.1",
+                            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
                             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                         },
                         "qs": {
-                            "version": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+                            "version": "6.4.0",
+                            "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
                             "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
                         },
                         "readable-stream": {
-                            "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                            "version": "1.1.14",
+                            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
                             "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                             "requires": {
-                                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                "isarray": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                                "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "0.0.1",
+                                "string_decoder": "~0.10.x"
                             }
                         },
                         "repeat-string": {
-                            "version": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+                            "version": "1.6.1",
+                            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
                             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
                         },
                         "replace-ext": {
-                            "version": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                            "version": "0.0.1",
+                            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
                             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
                         },
                         "request": {
-                            "version": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+                            "version": "2.81.0",
+                            "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
                             "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
                             "requires": {
-                                "aws-sign2": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                                "aws4": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-                                "caseless": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                                "combined-stream": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-                                "extend": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-                                "forever-agent": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-                                "form-data": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                                "har-validator": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                                "hawk": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-                                "http-signature": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                                "is-typedarray": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-                                "isstream": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-                                "json-stringify-safe": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-                                "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                                "oauth-sign": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-                                "performance-now": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                                "qs": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                                "stringstream": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-                                "tough-cookie": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-                                "tunnel-agent": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                                "uuid": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+                                "aws-sign2": "~0.6.0",
+                                "aws4": "^1.2.1",
+                                "caseless": "~0.12.0",
+                                "combined-stream": "~1.0.5",
+                                "extend": "~3.0.0",
+                                "forever-agent": "~0.6.1",
+                                "form-data": "~2.1.1",
+                                "har-validator": "~4.2.1",
+                                "hawk": "~3.1.3",
+                                "http-signature": "~1.1.0",
+                                "is-typedarray": "~1.0.0",
+                                "isstream": "~0.1.2",
+                                "json-stringify-safe": "~5.0.1",
+                                "mime-types": "~2.1.7",
+                                "oauth-sign": "~0.8.1",
+                                "performance-now": "^0.2.0",
+                                "qs": "~6.4.0",
+                                "safe-buffer": "^5.0.1",
+                                "stringstream": "~0.0.4",
+                                "tough-cookie": "~2.3.0",
+                                "tunnel-agent": "^0.6.0",
+                                "uuid": "^3.0.0"
                             }
                         },
                         "resolve": {
-                            "version": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                            "version": "1.1.7",
+                            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
                             "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
                         },
                         "right-align": {
-                            "version": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                            "version": "0.1.3",
+                            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
                             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                             "optional": true,
                             "requires": {
-                                "align-text": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+                                "align-text": "^0.1.1"
                             }
                         },
                         "safe-buffer": {
-                            "version": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                            "version": "5.1.1",
+                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
                             "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
                         },
                         "sntp": {
-                            "version": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                            "version": "1.0.9",
+                            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
                             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
                             "requires": {
-                                "hoek": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                                "hoek": "2.x.x"
                             }
                         },
                         "source-map": {
-                            "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+                            "version": "0.5.6",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
                             "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
                             "optional": true
                         },
                         "sparkles": {
-                            "version": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
                             "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
                         },
                         "sprintf-js": {
-                            "version": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
                             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
                         },
                         "sshpk": {
-                            "version": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                            "version": "1.13.1",
+                            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
                             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
                             "requires": {
-                                "asn1": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-                                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                "bcrypt-pbkdf": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                                "dashdash": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                                "ecc-jsbn": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                                "getpass": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                                "jsbn": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-                                "tweetnacl": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                                "asn1": "~0.2.3",
+                                "assert-plus": "^1.0.0",
+                                "bcrypt-pbkdf": "^1.0.0",
+                                "dashdash": "^1.12.0",
+                                "ecc-jsbn": "~0.1.1",
+                                "getpass": "^0.1.1",
+                                "jsbn": "~0.1.0",
+                                "tweetnacl": "~0.14.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                 }
                             }
                         },
                         "string_decoder": {
-                            "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                            "version": "0.10.31",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                             "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                         },
                         "stringstream": {
-                            "version": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+                            "version": "0.0.5",
+                            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
                             "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
                         },
                         "strip-ansi": {
-                            "version": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                            "version": "3.0.1",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
                             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                             "requires": {
-                                "ansi-regex": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                "ansi-regex": "^2.0.0"
                             }
                         },
                         "supports-color": {
-                            "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+                            "version": "3.1.2",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
                             "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
                             "requires": {
-                                "has-flag": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                                "has-flag": "^1.0.0"
                             }
                         },
                         "through2": {
-                            "version": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+                            "version": "2.0.3",
+                            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
                             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                             "requires": {
-                                "readable-stream": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                                "xtend": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                                "readable-stream": "^2.1.5",
+                                "xtend": "~4.0.1"
                             },
                             "dependencies": {
                                 "isarray": {
-                                    "version": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                                     "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                                 },
                                 "readable-stream": {
-                                    "version": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                                    "version": "2.3.3",
+                                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
                                     "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
                                     "requires": {
-                                        "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                        "inherits": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-                                        "isarray": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                                        "process-nextick-args": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                                        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-                                        "string_decoder": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-                                        "util-deprecate": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                                        "core-util-is": "~1.0.0",
+                                        "inherits": "~2.0.3",
+                                        "isarray": "~1.0.0",
+                                        "process-nextick-args": "~1.0.6",
+                                        "safe-buffer": "~5.1.1",
+                                        "string_decoder": "~1.0.3",
+                                        "util-deprecate": "~1.0.1"
                                     }
                                 },
                                 "string_decoder": {
-                                    "version": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                                    "version": "1.0.3",
+                                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
                                     "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
                                     "requires": {
-                                        "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                        "safe-buffer": "~5.1.0"
                                     }
                                 }
                             }
                         },
                         "time-stamp": {
-                            "version": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+                            "version": "1.1.0",
+                            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
                             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
                         },
                         "tough-cookie": {
-                            "version": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+                            "version": "2.3.2",
+                            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
                             "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
                             "requires": {
-                                "punycode": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                                "punycode": "^1.4.1"
                             }
                         },
                         "tunnel-agent": {
-                            "version": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+                            "version": "0.6.0",
+                            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
                             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                             "requires": {
-                                "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                                "safe-buffer": "^5.0.1"
                             }
                         },
                         "tweetnacl": {
-                            "version": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                            "version": "0.14.5",
+                            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
                             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                             "optional": true
                         },
                         "type-check": {
-                            "version": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+                            "version": "0.3.2",
+                            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                             "requires": {
-                                "prelude-ls": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                                "prelude-ls": "~1.1.2"
                             }
                         },
                         "type-detect": {
-                            "version": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
                             "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
                         },
                         "uglify-js": {
-                            "version": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+                            "version": "2.7.5",
+                            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
                             "integrity": "sha1-RhLAx7qu4rp8SH3kkErhIgefLKg=",
                             "optional": true,
                             "requires": {
-                                "async": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-                                "source-map": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-                                "uglify-to-browserify": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-                                "yargs": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+                                "async": "~0.2.6",
+                                "source-map": "~0.5.1",
+                                "uglify-to-browserify": "~1.0.0",
+                                "yargs": "~3.10.0"
                             },
                             "dependencies": {
                                 "async": {
-                                    "version": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                                    "version": "0.2.10",
+                                    "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
                                     "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
                                     "optional": true
                                 }
                             }
                         },
                         "uglify-to-browserify": {
-                            "version": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
                             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
                             "optional": true
                         },
                         "util-deprecate": {
-                            "version": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                         },
                         "uuid": {
-                            "version": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
                             "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
                         },
                         "verror": {
-                            "version": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+                            "version": "1.10.0",
+                            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
                             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
                             "requires": {
-                                "assert-plus": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                                "core-util-is": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-                                "extsprintf": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+                                "assert-plus": "^1.0.0",
+                                "core-util-is": "1.0.2",
+                                "extsprintf": "^1.2.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
-                                    "version": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                                    "version": "1.0.0",
+                                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                                     "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                                 }
                             }
                         },
                         "vinyl": {
-                            "version": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+                            "version": "0.5.3",
+                            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
                             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
                             "requires": {
-                                "clone": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
-                                "clone-stats": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
-                                "replace-ext": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                                "clone": "^1.0.0",
+                                "clone-stats": "^0.0.1",
+                                "replace-ext": "0.0.1"
                             }
                         },
                         "which": {
-                            "version": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
+                            "version": "1.2.12",
+                            "resolved": "https://registry.npmjs.org/which/-/which-1.2.12.tgz",
                             "integrity": "sha1-3me15FAmnxlJCe8j7OTr5Bb6EZI=",
                             "requires": {
-                                "isexe": "https://registry.npmjs.org/isexe/-/isexe-1.1.2.tgz"
+                                "isexe": "^1.1.1"
                             }
                         },
                         "window-size": {
-                            "version": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+                            "version": "0.1.0",
+                            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
                             "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
                             "optional": true
                         },
                         "wordwrap": {
-                            "version": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+                            "version": "1.0.0",
+                            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
                             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
                         },
                         "wrappy": {
-                            "version": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                         },
                         "xtend": {
-                            "version": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                            "version": "4.0.1",
+                            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
                             "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                         },
                         "yargs": {
-                            "version": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                            "version": "3.10.0",
+                            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
                             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                             "optional": true,
                             "requires": {
-                                "camelcase": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-                                "cliui": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                                "decamelize": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-                                "window-size": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                                "camelcase": "^1.0.2",
+                                "cliui": "^2.1.0",
+                                "decamelize": "^1.0.0",
+                                "window-size": "0.1.0"
                             }
                         }
                     }
@@ -17331,7 +17787,7 @@
                     "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
                     "optional": true,
                     "requires": {
-                        "align-text": "0.1.4"
+                        "align-text": "^0.1.1"
                     }
                 },
                 "source-map": {
@@ -17350,7 +17806,7 @@
                     "integrity": "sha512-qxzYsob3yv6U+xMzPrv170y8AwGP7i74g+pbixCfD6rgso8BscLT2qXIuz6TpOaiJZ3mFgT5O9lyT9nMU4LfaA==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 },
                 "type-check": {
@@ -17358,7 +17814,7 @@
                     "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
                     "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
                     "requires": {
-                        "prelude-ls": "1.1.2"
+                        "prelude-ls": "~1.1.2"
                     }
                 },
                 "type-detect": {
@@ -17372,9 +17828,9 @@
                     "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.6",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     }
                 },
                 "uglify-to-browserify": {
@@ -17388,7 +17844,7 @@
                     "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
                     "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
                     "requires": {
-                        "isexe": "2.0.0"
+                        "isexe": "^2.0.0"
                     }
                 },
                 "window-size": {
@@ -17413,9 +17869,9 @@
                     "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
                     "optional": true,
                     "requires": {
-                        "camelcase": "1.2.1",
-                        "cliui": "2.1.0",
-                        "decamelize": "1.2.0",
+                        "camelcase": "^1.0.2",
+                        "cliui": "^2.1.0",
+                        "decamelize": "^1.0.0",
                         "window-size": "0.1.0"
                     }
                 }
@@ -17427,9 +17883,9 @@
             "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
             "dev": true,
             "requires": {
-                "has": "1.0.1",
-                "postcss": "5.2.18",
-                "uniqs": "2.0.0"
+                "has": "^1.0.1",
+                "postcss": "^5.0.4",
+                "uniqs": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17444,11 +17900,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -17471,10 +17927,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -17489,7 +17945,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -17500,8 +17956,8 @@
             "integrity": "sha1-9MBtufZ7Yf0XxOJW5+PZUVv3Jv0=",
             "dev": true,
             "requires": {
-                "posthtml-parser": "0.2.1",
-                "posthtml-render": "1.1.4"
+                "posthtml-parser": "^0.2.0",
+                "posthtml-render": "^1.0.5"
             }
         },
         "posthtml-parser": {
@@ -17510,8 +17966,8 @@
             "integrity": "sha1-NdUw3jhnQMK6JP8usvrznM3ycd0=",
             "dev": true,
             "requires": {
-                "htmlparser2": "3.9.2",
-                "isobject": "2.1.0"
+                "htmlparser2": "^3.8.3",
+                "isobject": "^2.1.0"
             },
             "dependencies": {
                 "domhandler": {
@@ -17520,7 +17976,7 @@
                     "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "htmlparser2": {
@@ -17529,12 +17985,12 @@
                     "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0",
-                        "domhandler": "2.4.2",
-                        "domutils": "1.5.1",
-                        "entities": "1.1.1",
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.0.6"
+                        "domelementtype": "^1.3.0",
+                        "domhandler": "^2.3.0",
+                        "domutils": "^1.5.1",
+                        "entities": "^1.1.1",
+                        "inherits": "^2.0.1",
+                        "readable-stream": "^2.0.2"
                     }
                 }
             }
@@ -17561,9 +18017,9 @@
             "dev": true,
             "requires": {
                 "merge-options": "0.0.64",
-                "posthtml": "0.9.2",
-                "posthtml-parser": "0.2.1",
-                "posthtml-render": "1.1.4"
+                "posthtml": "^0.9.2",
+                "posthtml-parser": "^0.2.1",
+                "posthtml-render": "^1.0.6"
             }
         },
         "prelude-ls": {
@@ -17602,8 +18058,8 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "2.0.1",
-                "utila": "0.4.0"
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
             }
         },
         "private": {
@@ -17634,7 +18090,7 @@
             "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
             "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "promise-file-reader": {
@@ -17654,9 +18110,9 @@
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
             "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
             "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1"
+                "fbjs": "^0.8.16",
+                "loose-envify": "^1.3.1",
+                "object-assign": "^4.1.1"
             }
         },
         "protocols": {
@@ -17671,7 +18127,7 @@
             "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
             "dev": true,
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.6.0"
             }
         },
@@ -17693,11 +18149,11 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "parse-asn1": "5.1.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pump": {
@@ -17706,8 +18162,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "pumpify": {
@@ -17716,9 +18172,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -17745,8 +18201,8 @@
             "integrity": "sha1-u7aTucqRXCMlFbIosaArYJBD2+s=",
             "dev": true,
             "requires": {
-                "object-assign": "4.1.1",
-                "strict-uri-encode": "1.1.0"
+                "object-assign": "^4.1.0",
+                "strict-uri-encode": "^1.0.0"
             }
         },
         "querystring": {
@@ -17779,9 +18235,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -17804,7 +18260,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -17813,8 +18269,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.2"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -17850,7 +18306,7 @@
                         "depd": "1.1.1",
                         "inherits": "2.0.3",
                         "setprototypeof": "1.0.3",
-                        "statuses": "1.4.0"
+                        "statuses": ">= 1.3.1 < 2"
                     }
                 },
                 "iconv-lite": {
@@ -17879,10 +18335,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
                 "minimist": {
@@ -17899,11 +18355,11 @@
             "integrity": "sha512-sB9HpuyMZg5Yy+iIkraPv7/5uaMdUVpfitGFO5aOKKFE/rcEpWunaZdYjvTpPBHUsBrrEn/7qs/klD1YQPIQhA==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "dom-align": "1.6.7",
-                "prop-types": "15.6.1",
-                "rc-util": "4.5.0",
-                "shallowequal": "1.0.2"
+                "babel-runtime": "^6.26.0",
+                "dom-align": "1.x",
+                "prop-types": "^15.5.8",
+                "rc-util": "^4.0.4",
+                "shallowequal": "^1.0.2"
             }
         },
         "rc-animate": {
@@ -17912,9 +18368,9 @@
             "integrity": "sha512-DjJLTUQj7XKKcuS8cczN0uOLfuSmgrVXFGieP1SZc87xUUTFGh8B/KjNmEtlfvxkSrSuVfb2rrEPER4SqKUtEA==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "css-animation": "1.4.1",
-                "prop-types": "15.6.1"
+                "babel-runtime": "6.x",
+                "css-animation": "^1.3.2",
+                "prop-types": "15.x"
             }
         },
         "rc-dropdown": {
@@ -17923,10 +18379,10 @@
             "integrity": "sha512-vdt2JH6gP16B5UupbWk4WGe4t4okg6tZtCKShTm47yQpgk0jpw67aS8MWUVYxtgZChgYrvF4Q/uAgAx6vdetIg==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.1",
-                "rc-trigger": "2.4.2",
-                "react-lifecycles-compat": "3.0.4"
+                "babel-runtime": "^6.26.0",
+                "prop-types": "^15.5.8",
+                "rc-trigger": "^2.2.2",
+                "react-lifecycles-compat": "^3.0.2"
             }
         },
         "rc-hammerjs": {
@@ -17935,9 +18391,9 @@
             "integrity": "sha512-4llgWO3RgLyVbEqUdGsDfzUDqklRlQW5VEhE3x35IvhV+w//VPRG34SBavK3D2mD/UaLKaohgU41V4agiftC8g==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "hammerjs": "2.0.8",
-                "prop-types": "15.6.1"
+                "babel-runtime": "6.x",
+                "hammerjs": "^2.0.8",
+                "prop-types": "^15.5.9"
             }
         },
         "rc-progress": {
@@ -17946,8 +18402,8 @@
             "integrity": "sha1-5h0FRL+dQgjlujL8UJYhWef5UqM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.1"
+                "babel-runtime": "6.x",
+                "prop-types": "^15.5.8"
             }
         },
         "rc-tabs": {
@@ -17956,14 +18412,14 @@
             "integrity": "sha512-pUFHtpmoQjBRN7JWYlYWS+d2cwIlo+dgMD5J7+czyVThYhhbmdi/3ZbaRU6txuQfK3to4S6e31hJSD+wXcQU4w==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "classnames": "2.2.5",
-                "create-react-class": "15.6.3",
-                "lodash": "4.17.10",
-                "prop-types": "15.6.1",
-                "rc-hammerjs": "0.6.9",
-                "rc-util": "4.5.0",
-                "warning": "3.0.0"
+                "babel-runtime": "6.x",
+                "classnames": "2.x",
+                "create-react-class": "15.x",
+                "lodash": "^4.17.5",
+                "prop-types": "15.x",
+                "rc-hammerjs": "~0.6.0",
+                "rc-util": "^4.0.4",
+                "warning": "^3.0.0"
             }
         },
         "rc-tree": {
@@ -17972,12 +18428,12 @@
             "integrity": "sha512-Vof0KscpGA6XmWZ78rN9ul0ZzGIhjR/FrUaDgGGNgIiobxpSH3gg08C3Ae739NZ9c9a5ZuHYf/czLYfh+z5Xpg==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "classnames": "2.2.5",
-                "prop-types": "15.6.1",
-                "rc-animate": "2.4.4",
-                "rc-util": "4.5.0",
-                "warning": "3.0.0"
+                "babel-runtime": "^6.23.0",
+                "classnames": "2.x",
+                "prop-types": "^15.5.8",
+                "rc-animate": "2.x",
+                "rc-util": "^4.0.4",
+                "warning": "^3.0.0"
             }
         },
         "rc-tree-select": {
@@ -17986,13 +18442,13 @@
             "integrity": "sha512-6OdmAbAj6IGb4F+klX6EZAUOFu0a7irSFPYolVMPQtWNWYcAQZNqkeiadqb/FWOBcbofZHDPDC4GGqiREo9ZOw==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "classnames": "2.2.5",
-                "prop-types": "15.6.1",
-                "rc-animate": "2.4.4",
-                "rc-tree": "1.7.11",
-                "rc-trigger": "2.4.2",
-                "rc-util": "4.5.0"
+                "babel-runtime": "^6.23.0",
+                "classnames": "^2.2.1",
+                "prop-types": "^15.5.8",
+                "rc-animate": "^2.0.2",
+                "rc-tree": "~1.7.1",
+                "rc-trigger": "^2.2.2",
+                "rc-util": "^4.5.0"
             }
         },
         "rc-trigger": {
@@ -18001,11 +18457,11 @@
             "integrity": "sha512-Llah3E8bhP0N1ubpZbVjaUGcYkDcBrDibh2a1Idk+gNslZqgpfOla1LPnwWb9liBr25+6J1S22Qr76ObEOHgDQ==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.1",
-                "rc-align": "2.3.6",
-                "rc-animate": "2.4.4",
-                "rc-util": "4.5.0"
+                "babel-runtime": "6.x",
+                "prop-types": "15.x",
+                "rc-align": "2.x",
+                "rc-animate": "2.x",
+                "rc-util": "^4.4.0"
             }
         },
         "rc-util": {
@@ -18014,10 +18470,10 @@
             "integrity": "sha512-KYuFBBqxCFI8fb4Wva+X3fmAZpGPo4i9gTNdsVKldHVi3hrnv3VawF89CPndxfsV5QT3J+ic76X5c4erQETi1w==",
             "dev": true,
             "requires": {
-                "add-dom-event-listener": "1.0.2",
-                "babel-runtime": "6.26.0",
-                "prop-types": "15.6.1",
-                "shallowequal": "0.2.2"
+                "add-dom-event-listener": "1.x",
+                "babel-runtime": "6.x",
+                "prop-types": "^15.5.10",
+                "shallowequal": "^0.2.2"
             },
             "dependencies": {
                 "shallowequal": {
@@ -18026,7 +18482,7 @@
                     "integrity": "sha1-HjL9W8q2rWiKSBLLDMBO/HXHAU4=",
                     "dev": true,
                     "requires": {
-                        "lodash.keys": "3.1.2"
+                        "lodash.keys": "^3.1.2"
                     }
                 }
             }
@@ -18037,10 +18493,10 @@
             "integrity": "sha512-FQfiFfk2z2Fk87OngNJHT05KyC9DOVn8LPeB7ZX+9u5+yU1JK6o5ozRlU3PeOMr0IFkWNvgn9jU8/IhRxR1F0g==",
             "dev": true,
             "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.1"
+                "fbjs": "^0.8.16",
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.0"
             }
         },
         "react-dom": {
@@ -18049,10 +18505,10 @@
             "integrity": "sha512-q06jiwST8SEPAMIEkAsu7BgynEZtqF87VrTc70XsW7nxVhWEu2Y4MF5UfxxHQO/mNtQHQWP0YcFxmwm9oMrMaQ==",
             "dev": true,
             "requires": {
-                "fbjs": "0.8.16",
-                "loose-envify": "1.3.1",
-                "object-assign": "4.1.1",
-                "prop-types": "15.6.1"
+                "fbjs": "^0.8.16",
+                "loose-envify": "^1.1.0",
+                "object-assign": "^4.1.1",
+                "prop-types": "^15.6.0"
             }
         },
         "react-lifecycles-compat": {
@@ -18067,10 +18523,10 @@
             "integrity": "sha512-xBChRXwBSa41jV/pXS3btAZqno3BJk1kK/fUBlyF9vvaDoULLFeSQKW/tfwIadEhNCaoSKN4hIdlowvOmC34Gg==",
             "dev": true,
             "requires": {
-                "exenv": "1.2.2",
-                "prop-types": "15.6.1",
-                "react-lifecycles-compat": "3.0.4",
-                "warning": "3.0.0"
+                "exenv": "^1.2.0",
+                "prop-types": "^15.5.10",
+                "react-lifecycles-compat": "^3.0.0",
+                "warning": "^3.0.0"
             }
         },
         "react-toastify": {
@@ -18078,9 +18534,9 @@
             "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-4.0.1.tgz",
             "integrity": "sha512-CyqSZQw39pIP1SbAddLUCnet8qYBAeLZnGJY8HC/VxBVwGbn4n6DDTapZlvQWkHdAnAQyJuAT4ETctImsSKz0Q==",
             "requires": {
-                "classnames": "2.2.5",
-                "prop-types": "15.6.1",
-                "react-transition-group": "2.3.1"
+                "classnames": "^2.2.5",
+                "prop-types": "^15.6.0",
+                "react-transition-group": "^2.2.1"
             }
         },
         "react-transition-group": {
@@ -18088,9 +18544,9 @@
             "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.3.1.tgz",
             "integrity": "sha512-hu4/LAOFSKjWt1+1hgnOv3ldxmt6lvZGTWz4KUkFrqzXrNDIVSu6txIcPszw7PNduR8en9YTN55JLRyd/L1ZiQ==",
             "requires": {
-                "dom-helpers": "3.3.1",
-                "loose-envify": "1.3.1",
-                "prop-types": "15.6.1"
+                "dom-helpers": "^3.3.1",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.1"
             }
         },
         "read-chunk": {
@@ -18099,8 +18555,8 @@
             "integrity": "sha1-agTAkoAF7Z1C4aasVgDhnLx/9lU=",
             "dev": true,
             "requires": {
-                "pify": "3.0.0",
-                "safe-buffer": "5.1.2"
+                "pify": "^3.0.0",
+                "safe-buffer": "^5.1.1"
             }
         },
         "read-pkg": {
@@ -18109,9 +18565,9 @@
             "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
             "dev": true,
             "requires": {
-                "load-json-file": "2.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "2.0.0"
+                "load-json-file": "^2.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^2.0.0"
             },
             "dependencies": {
                 "path-type": {
@@ -18120,7 +18576,7 @@
                     "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
                     "dev": true,
                     "requires": {
-                        "pify": "2.3.0"
+                        "pify": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -18137,8 +18593,8 @@
             "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "2.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^2.0.0"
             }
         },
         "readable-stream": {
@@ -18146,12 +18602,12 @@
             "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~0.10.x",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdirp": {
@@ -18160,10 +18616,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.0.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "recast": {
@@ -18173,9 +18629,9 @@
             "dev": true,
             "requires": {
                 "ast-types": "0.9.6",
-                "esprima": "3.1.3",
-                "private": "0.1.8",
-                "source-map": "0.5.7"
+                "esprima": "~3.1.0",
+                "private": "~0.1.5",
+                "source-map": "~0.5.0"
             },
             "dependencies": {
                 "esprima": {
@@ -18197,7 +18653,7 @@
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "requires": {
-                "resolve": "1.7.1"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -18206,8 +18662,8 @@
             "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
             "dev": true,
             "requires": {
-                "indent-string": "3.2.0",
-                "strip-indent": "2.0.0"
+                "indent-string": "^3.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "redeyed": {
@@ -18216,7 +18672,7 @@
             "integrity": "sha1-6WwZO0DAgWsArshCaY5hGF5VSYo=",
             "dev": true,
             "requires": {
-                "esprima": "3.0.0"
+                "esprima": "~3.0.0"
             },
             "dependencies": {
                 "esprima": {
@@ -18233,9 +18689,9 @@
             "integrity": "sha1-dHyRTgSWFKTJz7umKYca0dKSdxY=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2",
-                "math-expression-evaluator": "1.2.17",
-                "reduce-function-call": "1.0.2"
+                "balanced-match": "^0.4.2",
+                "math-expression-evaluator": "^1.2.14",
+                "reduce-function-call": "^1.0.1"
             },
             "dependencies": {
                 "balanced-match": {
@@ -18252,7 +18708,7 @@
             "integrity": "sha1-WiAL+S4ON3UXUv5FsKszD9S2vpk=",
             "dev": true,
             "requires": {
-                "balanced-match": "0.4.2"
+                "balanced-match": "^0.4.2"
             },
             "dependencies": {
                 "balanced-match": {
@@ -18281,9 +18737,9 @@
             "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "babel-types": "6.26.0",
-                "private": "0.1.8"
+                "babel-runtime": "^6.18.0",
+                "babel-types": "^6.19.0",
+                "private": "^0.1.6"
             }
         },
         "regex-cache": {
@@ -18292,7 +18748,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -18301,8 +18757,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regexp-replace-loader": {
@@ -18311,7 +18767,7 @@
             "integrity": "sha1-Xa5zvp7oKk2U0JVcL6P8kj4TTX4=",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.0.2"
             }
         },
         "regexpp": {
@@ -18326,9 +18782,9 @@
             "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
             "dev": true,
             "requires": {
-                "regenerate": "1.4.0",
-                "regjsgen": "0.2.0",
-                "regjsparser": "0.1.5"
+                "regenerate": "^1.2.1",
+                "regjsgen": "^0.2.0",
+                "regjsparser": "^0.1.4"
             }
         },
         "registry-auth-token": {
@@ -18337,8 +18793,8 @@
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "dev": true,
             "requires": {
-                "rc": "1.2.8",
-                "safe-buffer": "5.1.2"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "regjsgen": {
@@ -18353,7 +18809,7 @@
             "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
             "dev": true,
             "requires": {
-                "jsesc": "0.5.0"
+                "jsesc": "~0.5.0"
             },
             "dependencies": {
                 "jsesc": {
@@ -18382,11 +18838,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-converter": "0.1.4",
-                "htmlparser2": "3.3.0",
-                "strip-ansi": "3.0.1",
-                "utila": "0.3.3"
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.1",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -18415,7 +18871,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -18448,8 +18904,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requires-port": {
@@ -18463,7 +18919,7 @@
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-cwd": {
@@ -18472,7 +18928,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -18489,8 +18945,8 @@
             "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "1.2.2",
-                "global-modules": "0.2.3"
+                "expand-tilde": "^1.2.2",
+                "global-modules": "^0.2.3"
             }
         },
         "resolve-from": {
@@ -18511,7 +18967,7 @@
             "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
             "dev": true,
             "requires": {
-                "lowercase-keys": "1.0.1"
+                "lowercase-keys": "^1.0.0"
             }
         },
         "restore-cursor": {
@@ -18520,8 +18976,8 @@
             "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
             "dev": true,
             "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
             }
         },
         "ret": {
@@ -18543,7 +18999,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "right-pad": {
@@ -18558,7 +19014,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -18567,8 +19023,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "riveter": {
@@ -18576,7 +19032,7 @@
             "resolved": "https://registry.npmjs.org/riveter/-/riveter-0.2.0.tgz",
             "integrity": "sha1-H3yOhlxFURX95ZS+JLAHLr3IvuQ=",
             "requires": {
-                "lodash": "2.4.2"
+                "lodash": "^2.4.1"
             },
             "dependencies": {
                 "lodash": {
@@ -18592,7 +19048,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "run-queue": {
@@ -18601,7 +19057,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
             }
         },
         "rx": {
@@ -18622,7 +19078,7 @@
             "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
             "dev": true,
             "requires": {
-                "rx-lite": "4.0.8"
+                "rx-lite": "*"
             }
         },
         "rxjs": {
@@ -18646,7 +19102,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -18666,8 +19122,8 @@
             "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
             "dev": true,
             "requires": {
-                "ajv": "6.5.0",
-                "ajv-keywords": "3.2.0"
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
             },
             "dependencies": {
                 "ajv": {
@@ -18676,10 +19132,10 @@
                     "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0",
+                        "uri-js": "^4.2.1"
                     }
                 },
                 "ajv-keywords": {
@@ -18728,31 +19184,31 @@
             "integrity": "sha512-wnQZl8hv37IWLx62LUQnA4paS9z/dY7fBoStF43AILQUldxhArxfuuQxaA11TAnxeFA4Z0PHIPwRwVO8qg6Emw==",
             "dev": true,
             "requires": {
-                "@semantic-release/commit-analyzer": "5.0.3",
-                "@semantic-release/error": "2.2.0",
-                "@semantic-release/github": "4.2.17",
-                "@semantic-release/npm": "3.3.1",
-                "@semantic-release/release-notes-generator": "6.0.10",
-                "aggregate-error": "1.0.0",
-                "chalk": "2.4.1",
-                "cosmiconfig": "4.0.0",
-                "debug": "3.1.0",
-                "env-ci": "1.7.2",
-                "execa": "0.10.0",
-                "get-stream": "3.0.0",
-                "git-log-parser": "1.2.0",
-                "git-url-parse": "8.3.1",
-                "hook-std": "0.4.0",
-                "hosted-git-info": "2.6.0",
-                "lodash": "4.17.10",
-                "marked": "0.3.19",
-                "marked-terminal": "2.0.0",
-                "p-locate": "2.0.0",
-                "p-reduce": "1.0.0",
-                "read-pkg-up": "3.0.0",
-                "resolve-from": "4.0.0",
-                "semver": "5.5.0",
-                "yargs": "11.0.0"
+                "@semantic-release/commit-analyzer": "^5.0.0",
+                "@semantic-release/error": "^2.2.0",
+                "@semantic-release/github": "^4.1.0",
+                "@semantic-release/npm": "^3.2.0",
+                "@semantic-release/release-notes-generator": "^6.0.0",
+                "aggregate-error": "^1.0.0",
+                "chalk": "^2.3.0",
+                "cosmiconfig": "^4.0.0",
+                "debug": "^3.1.0",
+                "env-ci": "^1.0.0",
+                "execa": "^0.10.0",
+                "get-stream": "^3.0.0",
+                "git-log-parser": "^1.2.0",
+                "git-url-parse": "^8.3.1",
+                "hook-std": "^0.4.0",
+                "hosted-git-info": "^2.6.0",
+                "lodash": "^4.17.4",
+                "marked": "^0.3.9",
+                "marked-terminal": "^2.0.0",
+                "p-locate": "^2.0.0",
+                "p-reduce": "^1.0.0",
+                "read-pkg-up": "^3.0.0",
+                "resolve-from": "^4.0.0",
+                "semver": "^5.4.1",
+                "yargs": "^11.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -18773,9 +19229,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "cosmiconfig": {
@@ -18784,10 +19240,10 @@
                     "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
                     "dev": true,
                     "requires": {
-                        "is-directory": "0.3.1",
-                        "js-yaml": "3.11.0",
-                        "parse-json": "4.0.0",
-                        "require-from-string": "2.0.2"
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^4.0.0",
+                        "require-from-string": "^2.0.1"
                     }
                 },
                 "esprima": {
@@ -18808,8 +19264,8 @@
                     "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "load-json-file": {
@@ -18818,10 +19274,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "os-locale": {
@@ -18830,9 +19286,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     },
                     "dependencies": {
                         "execa": {
@@ -18841,13 +19297,13 @@
                             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                             "dev": true,
                             "requires": {
-                                "cross-spawn": "5.1.0",
-                                "get-stream": "3.0.0",
-                                "is-stream": "1.1.0",
-                                "npm-run-path": "2.0.2",
-                                "p-finally": "1.0.0",
-                                "signal-exit": "3.0.2",
-                                "strip-eof": "1.0.0"
+                                "cross-spawn": "^5.0.1",
+                                "get-stream": "^3.0.0",
+                                "is-stream": "^1.1.0",
+                                "npm-run-path": "^2.0.0",
+                                "p-finally": "^1.0.0",
+                                "signal-exit": "^3.0.0",
+                                "strip-eof": "^1.0.0"
                             }
                         }
                     }
@@ -18858,8 +19314,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "read-pkg": {
@@ -18868,9 +19324,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -18879,8 +19335,8 @@
                     "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 },
                 "require-from-string": {
@@ -18901,8 +19357,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -18911,7 +19367,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "which-module": {
@@ -18932,18 +19388,18 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     }
                 },
                 "yargs-parser": {
@@ -18952,7 +19408,7 @@
                     "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -18970,18 +19426,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.3",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.4.0"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
             },
             "dependencies": {
                 "debug": {
@@ -19013,13 +19469,13 @@
             "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
-                "escape-html": "1.0.3",
-                "http-errors": "1.6.3",
-                "mime-types": "2.1.18",
-                "parseurl": "1.3.2"
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
             },
             "dependencies": {
                 "debug": {
@@ -19039,9 +19495,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -19063,10 +19519,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -19075,7 +19531,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -19097,8 +19553,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shader-loader": {
@@ -19107,7 +19563,7 @@
             "integrity": "sha512-dt8F9K0x4rjmaFyHh7rNDfpt4LUiR64zhNIEwp2WbE99B3z4ALuvvmhftkElg93dUD6sTmv/aXa/z9SJiEddcA==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0"
+                "loader-utils": "^1.1.0"
             }
         },
         "shallowequal": {
@@ -19122,7 +19578,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -19136,9 +19592,9 @@
             "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
             "requires": {
-                "glob": "7.1.2",
-                "interpret": "1.1.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             }
         },
         "shx": {
@@ -19147,9 +19603,9 @@
             "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
             "dev": true,
             "requires": {
-                "es6-object-assign": "1.1.0",
-                "minimist": "1.2.0",
-                "shelljs": "0.7.8"
+                "es6-object-assign": "^1.0.3",
+                "minimist": "^1.2.0",
+                "shelljs": "^0.7.3"
             },
             "dependencies": {
                 "minimist": {
@@ -19172,22 +19628,22 @@
             "integrity": "sha512-6dUaGvU18xiAyfywp6D5bDOsRpukzOWvYZEgr6Ju2ZmLFXcelt6LXi/g3IzJ0LkCRNiEvFF6NYcCGT9qa4sj6Q==",
             "dev": true,
             "requires": {
-                "bytes": "3.0.0",
-                "chalk": "2.4.1",
-                "ci-job-number": "0.3.0",
-                "compression-webpack-plugin": "1.1.11",
-                "cosmiconfig": "4.0.0",
-                "css-loader": "0.28.11",
-                "escape-string-regexp": "1.0.5",
-                "file-loader": "1.1.11",
-                "globby": "8.0.1",
-                "gzip-size": "4.1.0",
-                "memory-fs": "0.4.1",
-                "read-pkg-up": "3.0.0",
-                "style-loader": "0.20.3",
-                "webpack": "4.5.0",
-                "webpack-bundle-analyzer": "2.13.1",
-                "yargs": "11.0.0"
+                "bytes": "^3.0.0",
+                "chalk": "^2.3.2",
+                "ci-job-number": "^0.3.0",
+                "compression-webpack-plugin": "^1.1.11",
+                "cosmiconfig": "^4.0.0",
+                "css-loader": "^0.28.11",
+                "escape-string-regexp": "^1.0.5",
+                "file-loader": "^1.1.11",
+                "globby": "^8.0.1",
+                "gzip-size": "^4.1.0",
+                "memory-fs": "^0.4.1",
+                "read-pkg-up": "^3.0.0",
+                "style-loader": "^0.20.3",
+                "webpack": "^4.1.1",
+                "webpack-bundle-analyzer": "^2.11.1",
+                "yargs": "^11.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -19208,9 +19664,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "cosmiconfig": {
@@ -19219,10 +19675,10 @@
                     "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
                     "dev": true,
                     "requires": {
-                        "is-directory": "0.3.1",
-                        "js-yaml": "3.11.0",
-                        "parse-json": "4.0.0",
-                        "require-from-string": "2.0.2"
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^4.0.0",
+                        "require-from-string": "^2.0.1"
                     }
                 },
                 "esprima": {
@@ -19237,13 +19693,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "globby": {
@@ -19252,13 +19708,13 @@
                     "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "dir-glob": "2.0.0",
-                        "fast-glob": "2.2.2",
-                        "glob": "7.1.2",
-                        "ignore": "3.3.8",
-                        "pify": "3.0.0",
-                        "slash": "1.0.0"
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "fast-glob": "^2.0.2",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -19273,8 +19729,8 @@
                     "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
                     "dev": true,
                     "requires": {
-                        "argparse": "1.0.10",
-                        "esprima": "4.0.0"
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
                     }
                 },
                 "load-json-file": {
@@ -19283,10 +19739,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "memory-fs": {
@@ -19295,8 +19751,8 @@
                     "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
                     "dev": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "readable-stream": "2.0.6"
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "os-locale": {
@@ -19305,9 +19761,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "parse-json": {
@@ -19316,8 +19772,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "read-pkg": {
@@ -19326,9 +19782,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -19337,8 +19793,8 @@
                     "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 },
                 "require-from-string": {
@@ -19353,8 +19809,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -19363,7 +19819,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "webpack-bundle-analyzer": {
@@ -19372,18 +19828,18 @@
                     "integrity": "sha512-rwxyfecTAxoarCC9VlHlIpfQCmmJ/qWD5bpbjkof+7HrNhTNZIwZITxN6CdlYL2axGmwNUQ+tFgcSOiNXMf/sQ==",
                     "dev": true,
                     "requires": {
-                        "acorn": "5.6.0",
-                        "bfj-node4": "5.3.1",
-                        "chalk": "2.4.1",
-                        "commander": "2.13.0",
-                        "ejs": "2.6.1",
-                        "express": "4.16.3",
-                        "filesize": "3.6.1",
-                        "gzip-size": "4.1.0",
-                        "lodash": "4.17.10",
-                        "mkdirp": "0.5.1",
-                        "opener": "1.4.3",
-                        "ws": "4.1.0"
+                        "acorn": "^5.3.0",
+                        "bfj-node4": "^5.2.0",
+                        "chalk": "^2.3.0",
+                        "commander": "^2.13.0",
+                        "ejs": "^2.5.7",
+                        "express": "^4.16.2",
+                        "filesize": "^3.5.11",
+                        "gzip-size": "^4.1.0",
+                        "lodash": "^4.17.4",
+                        "mkdirp": "^0.5.1",
+                        "opener": "^1.4.3",
+                        "ws": "^4.0.0"
                     }
                 },
                 "which-module": {
@@ -19404,18 +19860,18 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     }
                 },
                 "yargs-parser": {
@@ -19424,7 +19880,7 @@
                     "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -19441,7 +19897,7 @@
             "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0"
+                "is-fullwidth-code-point": "^2.0.0"
             },
             "dependencies": {
                 "is-fullwidth-code-point": {
@@ -19464,14 +19920,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -19489,7 +19945,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -19498,7 +19954,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "source-map": {
@@ -19515,9 +19971,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -19526,7 +19982,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -19535,7 +19991,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -19544,7 +20000,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -19553,9 +20009,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -19578,7 +20034,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sockjs": {
@@ -19587,8 +20043,8 @@
             "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
             "dev": true,
             "requires": {
-                "faye-websocket": "0.10.0",
-                "uuid": "3.2.1"
+                "faye-websocket": "^0.10.0",
+                "uuid": "^3.0.1"
             }
         },
         "sockjs-client": {
@@ -19597,12 +20053,12 @@
             "integrity": "sha1-W6vjhrd15M8U51IJEUUmVAFsixI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
+                "debug": "^2.6.6",
                 "eventsource": "0.1.6",
-                "faye-websocket": "0.11.1",
-                "inherits": "2.0.3",
-                "json3": "3.3.2",
-                "url-parse": "1.4.0"
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
             },
             "dependencies": {
                 "debug": {
@@ -19620,7 +20076,7 @@
                     "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
                     "dev": true,
                     "requires": {
-                        "websocket-driver": "0.7.0"
+                        "websocket-driver": ">=0.5.1"
                     }
                 }
             }
@@ -19631,7 +20087,7 @@
             "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
             "dev": true,
             "requires": {
-                "is-plain-obj": "1.1.0"
+                "is-plain-obj": "^1.0.0"
             }
         },
         "source-list-map": {
@@ -19652,11 +20108,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.1",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -19665,7 +20121,7 @@
             "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "source-map": {
@@ -19694,8 +20150,8 @@
             "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "os-shim": "0.1.3"
+                "concat-stream": "^1.4.7",
+                "os-shim": "^0.1.2"
             }
         },
         "spdx-correct": {
@@ -19704,8 +20160,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -19720,8 +20176,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -19736,12 +20192,12 @@
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
-                "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.2",
-                "select-hose": "2.0.0",
-                "spdy-transport": "2.1.0"
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
             },
             "dependencies": {
                 "debug": {
@@ -19761,13 +20217,13 @@
             "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "detect-node": "2.0.3",
-                "hpack.js": "2.1.6",
-                "obuf": "1.1.2",
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2",
-                "wbuf": "1.7.3"
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
             },
             "dependencies": {
                 "debug": {
@@ -19791,13 +20247,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -19806,7 +20262,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -19817,7 +20273,7 @@
             "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -19826,7 +20282,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "split2": {
@@ -19835,7 +20291,7 @@
             "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.2"
             }
         },
         "sprintf-js": {
@@ -19850,7 +20306,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
             }
         },
         "static-extend": {
@@ -19859,8 +20315,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -19869,7 +20325,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -19886,8 +20342,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.0.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-combiner2": {
@@ -19896,8 +20352,8 @@
             "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
             "dev": true,
             "requires": {
-                "duplexer2": "0.1.4",
-                "readable-stream": "2.0.6"
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-each": {
@@ -19906,8 +20362,8 @@
             "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "stream-http": {
@@ -19916,11 +20372,11 @@
             "integrity": "sha512-QllfrBhqF1DPcz46WxKTs6Mz1Bpc+8Qm6vbqOpVav5odAXwbyzwnEczoWqtxrsmlO+cJqtPrp/8gWKWjaKLLlA==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -19935,13 +20391,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -19950,7 +20406,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -19967,7 +20423,7 @@
             "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
             "dev": true,
             "requires": {
-                "any-observable": "0.2.0"
+                "any-observable": "^0.2.0"
             }
         },
         "strict-uri-encode": {
@@ -19982,8 +20438,8 @@
             "integrity": "sha512-0Nvw1LDclF45AFNuYPcD2Jvkv0mwb/dQSnJZMvhqGrT+zzmrpG3OJFD600qfQfNUd5aqfp7fCm2mQMfF7zLbyQ==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.4.5"
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^0.4.5"
             }
         },
         "string-template": {
@@ -19998,9 +20454,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -20014,7 +20470,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -20029,8 +20485,8 @@
             "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "2.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
             },
             "dependencies": {
                 "strip-bom": {
@@ -20039,7 +20495,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -20068,8 +20524,8 @@
             "integrity": "sha512-2I7AVP73MvK33U7B9TKlYZAqdROyMXDYSMvHLX43qy3GCOaJNiV6i0v/sv9idWIaQ42Yn2dNv79Q5mKXbKhAZg==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.4.5"
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^0.4.5"
             }
         },
         "supports-color": {
@@ -20078,7 +20534,7 @@
             "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "svg-baker": {
@@ -20087,19 +20543,19 @@
             "integrity": "sha512-Tjx9jgFoNpWQPLFgxEXKvCOjbo+8xoAxR9beUcdeR4k+5RFISfteWu6Y6OR7FPEXVBBrQzoZQM5/gSYTVfKxiA==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "clone": "2.1.1",
-                "he": "1.1.1",
-                "image-size": "0.5.5",
-                "loader-utils": "1.1.0",
+                "bluebird": "^3.5.0",
+                "clone": "^2.1.1",
+                "he": "^1.1.1",
+                "image-size": "^0.5.1",
+                "loader-utils": "^1.1.0",
                 "merge-options": "0.0.64",
                 "micromatch": "3.1.0",
-                "postcss": "5.2.18",
-                "postcss-prefix-selector": "1.6.0",
-                "posthtml-rename-id": "1.0.7",
-                "posthtml-svg-mode": "1.0.2",
-                "query-string": "4.3.4",
-                "traverse": "0.6.6"
+                "postcss": "^5.2.17",
+                "postcss-prefix-selector": "^1.6.0",
+                "posthtml-rename-id": "^1.0",
+                "posthtml-svg-mode": "^1.0",
+                "query-string": "^4.3.2",
+                "traverse": "^0.6.6"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -20126,16 +20582,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     }
                 },
                 "chalk": {
@@ -20144,11 +20600,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -20180,7 +20636,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "expand-brackets": {
@@ -20189,13 +20645,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -20204,7 +20660,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -20213,7 +20669,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -20222,7 +20678,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -20233,7 +20689,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -20242,7 +20698,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -20253,9 +20709,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         }
                     }
@@ -20266,7 +20722,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "extglob": {
@@ -20275,14 +20731,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     }
                 },
                 "fill-range": {
@@ -20291,10 +20747,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     }
                 },
                 "has-flag": {
@@ -20309,7 +20765,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -20326,7 +20782,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -20343,9 +20799,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -20362,7 +20818,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -20371,7 +20827,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -20394,19 +20850,19 @@
                     "integrity": "sha512-3StSelAE+hnRvMs8IdVW7Uhk8CVed5tp+kLLGlBP6WiRAXS21GPGu/Nat4WNPXj2Eoc24B02SaeoyozPMfj0/g==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "1.0.0",
-                        "extend-shallow": "2.0.1",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "5.1.0",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.2.2",
+                        "define-property": "^1.0.0",
+                        "extend-shallow": "^2.0.1",
+                        "extglob": "^2.0.2",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^5.0.2",
+                        "nanomatch": "^1.2.1",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     }
                 },
                 "postcss": {
@@ -20415,10 +20871,10 @@
                     "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "js-base64": "2.4.5",
-                        "source-map": "0.5.7",
-                        "supports-color": "3.2.3"
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
                     }
                 },
                 "source-map": {
@@ -20433,7 +20889,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -20446,7 +20902,7 @@
             "requires": {
                 "deepmerge": "1.3.2",
                 "mitt": "1.1.2",
-                "svg-baker": "1.2.17"
+                "svg-baker": "^1.2.0"
             }
         },
         "svg-sprite-loader": {
@@ -20455,13 +20911,13 @@
             "integrity": "sha512-P53xc3RvqYCvT5shjk6QU+JsL559OT0Q3NuS0oKdIBYx9If4d2ezTvcZoK8tDCQtaFi24+pvA7rV7WBgmorFUg==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
+                "bluebird": "^3.5.0",
                 "deepmerge": "1.3.2",
                 "domready": "1.0.8",
                 "escape-string-regexp": "1.0.5",
-                "loader-utils": "1.1.0",
-                "svg-baker": "1.2.17",
-                "svg-baker-runtime": "1.3.5",
+                "loader-utils": "^1.1.0",
+                "svg-baker": "^1.2.17",
+                "svg-baker-runtime": "^1.3.3",
                 "url-slug": "2.0.0"
             }
         },
@@ -20471,13 +20927,13 @@
             "integrity": "sha1-n1dyQTlSE1xv779Ar+ak+qiLS7U=",
             "dev": true,
             "requires": {
-                "coa": "1.0.4",
-                "colors": "1.1.2",
-                "csso": "2.3.2",
-                "js-yaml": "3.7.0",
-                "mkdirp": "0.5.1",
-                "sax": "1.2.4",
-                "whet.extend": "0.9.9"
+                "coa": "~1.0.1",
+                "colors": "~1.1.2",
+                "csso": "~2.3.1",
+                "js-yaml": "~3.7.0",
+                "mkdirp": "~0.5.1",
+                "sax": "~1.2.1",
+                "whet.extend": "~0.9.9"
             },
             "dependencies": {
                 "colors": {
@@ -20500,12 +20956,12 @@
             "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "ajv-keywords": "2.1.1",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
+                "ajv": "^5.2.3",
+                "ajv-keywords": "^2.1.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -20526,8 +20982,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -20536,7 +20992,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -20553,8 +21009,8 @@
             "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2",
-                "rimraf": "2.2.8"
+                "os-tmpdir": "^1.0.0",
+                "rimraf": "~2.2.6"
             },
             "dependencies": {
                 "rimraf": {
@@ -20595,8 +21051,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -20611,13 +21067,13 @@
                     "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.2",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -20626,7 +21082,7 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.2"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
@@ -20649,7 +21105,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "tmp": {
@@ -20658,7 +21114,7 @@
             "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.1"
             }
         },
         "to-arraybuffer": {
@@ -20679,7 +21135,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -20688,10 +21144,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -20700,8 +21156,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -20710,7 +21166,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -20763,7 +21219,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-detect": {
@@ -20779,7 +21235,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.18"
+                "mime-types": "~2.1.18"
             }
         },
         "typedarray": {
@@ -20799,8 +21255,8 @@
             "integrity": "sha512-68Rc/aA6cswiaQ5SrE979UJcXX+ADA1z33/ZsPd+fbAiVdjZ16OXdbtGO+rJUUBgK6qdf3SOPhQf3K/ybF5Miw==",
             "dev": true,
             "requires": {
-                "commander": "2.15.1",
-                "source-map": "0.6.1"
+                "commander": "~2.15.0",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "commander": {
@@ -20824,14 +21280,14 @@
             "integrity": "sha512-z0IbjpW8b3O/OVn+TTZN4pI29RN1zktFBXLIzzfZ+++cUtZ1ERSlLWgpE/5OERuEUs1ijVQnpYAkSlpoVmQmSQ==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "schema-utils": "0.4.5",
-                "serialize-javascript": "1.5.0",
-                "source-map": "0.6.1",
-                "uglify-es": "3.3.9",
-                "webpack-sources": "1.1.0",
-                "worker-farm": "1.6.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "schema-utils": "^0.4.5",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "uglify-es": "^3.3.4",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
             },
             "dependencies": {
                 "uglify-es": {
@@ -20840,8 +21296,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.13.0",
-                        "source-map": "0.6.1"
+                        "commander": "~2.13.0",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -20876,7 +21332,7 @@
             "integrity": "sha1-GY+9rrolTniLDvy2MLwR8kopWeA=",
             "dev": true,
             "requires": {
-                "qs": "2.3.3"
+                "qs": "~2.3.3"
             }
         },
         "union-value": {
@@ -20885,10 +21341,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -20897,7 +21353,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -20906,10 +21362,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -20932,7 +21388,7 @@
             "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "dev": true,
             "requires": {
-                "unique-slug": "2.0.0"
+                "unique-slug": "^2.0.0"
             }
         },
         "unique-slug": {
@@ -20941,7 +21397,7 @@
             "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
             "dev": true,
             "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
             }
         },
         "universalify": {
@@ -20962,8 +21418,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -20972,9 +21428,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -21026,7 +21482,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -21073,9 +21529,9 @@
             "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "mime": "2.3.1",
-                "schema-utils": "0.4.5"
+                "loader-utils": "^1.1.0",
+                "mime": "^2.0.3",
+                "schema-utils": "^0.4.3"
             },
             "dependencies": {
                 "mime": {
@@ -21092,8 +21548,8 @@
             "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "url-parse-lax": {
@@ -21102,7 +21558,7 @@
             "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
             "dev": true,
             "requires": {
-                "prepend-http": "2.0.0"
+                "prepend-http": "^2.0.0"
             },
             "dependencies": {
                 "prepend-http": {
@@ -21140,7 +21596,7 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -21179,8 +21635,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "object.getownpropertydescriptors": "2.0.3"
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
             }
         },
         "utila": {
@@ -21213,8 +21669,8 @@
             "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "vary": {
@@ -21235,8 +21691,8 @@
             "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -21246,12 +21702,12 @@
             "integrity": "sha1-p+v1/779obfRjRQPyweyI++2dRo=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "2.0.0",
-                "vinyl": "1.2.0"
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.3.0",
+                "pinkie-promise": "^2.0.0",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^2.0.0",
+                "vinyl": "^1.1.0"
             },
             "dependencies": {
                 "pify": {
@@ -21266,7 +21722,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -21307,11 +21763,11 @@
                     "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.4.tgz",
                     "integrity": "sha512-z6w8iYIxZ/fcgul0j/OerkYnkomH8BZigvzbxVmr2h5HkZUrPtk2kjYtLkqR9wwQxEP6ecKNoKLsbhd18jfnGA==",
                     "requires": {
-                        "core-js": "2.3.0",
-                        "es6-promise": "3.0.2",
-                        "lie": "3.1.1",
-                        "pako": "1.0.6",
-                        "readable-stream": "2.0.6"
+                        "core-js": "~2.3.0",
+                        "es6-promise": "~3.0.2",
+                        "lie": "~3.1.0",
+                        "pako": "~1.0.2",
+                        "readable-stream": "~2.0.6"
                     }
                 }
             }
@@ -21322,7 +21778,7 @@
             "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
             "dev": true,
             "requires": {
-                "loose-envify": "1.3.1"
+                "loose-envify": "^1.0.0"
             }
         },
         "watchpack": {
@@ -21331,9 +21787,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.3",
-                "graceful-fs": "4.1.11",
-                "neo-async": "2.5.1"
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
             }
         },
         "wbuf": {
@@ -21342,7 +21798,7 @@
             "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
             "dev": true,
             "requires": {
-                "minimalistic-assert": "1.0.1"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "webpack": {
@@ -21351,25 +21807,25 @@
             "integrity": "sha512-6GrZsvQJnG7o7mjbfjp6s5CyMfdopjt1A/X8LcYwceis9ySjqBX6Lusso2wNZ06utHj2ZvfL6L3f7hfgVeJP6g==",
             "dev": true,
             "requires": {
-                "acorn": "5.6.0",
-                "acorn-dynamic-import": "3.0.0",
-                "ajv": "6.5.0",
-                "ajv-keywords": "3.2.0",
-                "chrome-trace-event": "0.1.3",
-                "enhanced-resolve": "4.0.0",
-                "eslint-scope": "3.7.1",
-                "loader-runner": "2.3.0",
-                "loader-utils": "1.1.0",
-                "memory-fs": "0.4.1",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "neo-async": "2.5.1",
-                "node-libs-browser": "2.1.0",
-                "schema-utils": "0.4.5",
-                "tapable": "1.0.0",
-                "uglifyjs-webpack-plugin": "1.2.4",
-                "watchpack": "1.6.0",
-                "webpack-sources": "1.1.0"
+                "acorn": "^5.0.0",
+                "acorn-dynamic-import": "^3.0.0",
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0",
+                "chrome-trace-event": "^0.1.1",
+                "enhanced-resolve": "^4.0.0",
+                "eslint-scope": "^3.7.1",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^1.1.0",
+                "memory-fs": "~0.4.1",
+                "micromatch": "^3.1.8",
+                "mkdirp": "~0.5.0",
+                "neo-async": "^2.5.0",
+                "node-libs-browser": "^2.0.0",
+                "schema-utils": "^0.4.2",
+                "tapable": "^1.0.0",
+                "uglifyjs-webpack-plugin": "^1.2.4",
+                "watchpack": "^1.5.0",
+                "webpack-sources": "^1.0.1"
             },
             "dependencies": {
                 "ajv": {
@@ -21378,10 +21834,10 @@
                     "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "2.0.1",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1",
-                        "uri-js": "4.2.2"
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0",
+                        "uri-js": "^4.2.1"
                     }
                 },
                 "ajv-keywords": {
@@ -21408,16 +21864,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -21426,7 +21882,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21446,9 +21902,9 @@
                     "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "memory-fs": "0.4.1",
-                        "tapable": "1.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "tapable": "^1.0.0"
                     }
                 },
                 "expand-brackets": {
@@ -21457,13 +21913,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -21472,7 +21928,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -21481,7 +21937,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -21490,7 +21946,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -21499,7 +21955,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -21510,7 +21966,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -21519,7 +21975,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -21530,9 +21986,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -21549,14 +22005,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -21565,7 +22021,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -21574,7 +22030,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21591,10 +22047,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -21603,7 +22059,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21614,7 +22070,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -21623,7 +22079,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -21632,9 +22088,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -21643,7 +22099,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -21652,7 +22108,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -21675,8 +22131,8 @@
                     "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
                     "dev": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "readable-stream": "2.0.6"
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "micromatch": {
@@ -21685,19 +22141,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.9",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "tapable": {
@@ -21714,7 +22170,7 @@
             "integrity": "sha512-MGO0nVniCLFAQz1qv22zM02QPjcpAoJdy7ED0i3Zy7SY1IecgXCm460ib7H/Wq7e9oL5VL6S2BxaObxwIcag0g==",
             "dev": true,
             "requires": {
-                "jscodeshift": "0.4.1"
+                "jscodeshift": "^0.4.0"
             },
             "dependencies": {
                 "ast-types": {
@@ -21747,21 +22203,21 @@
                     "integrity": "sha512-iOX6If+hsw0q99V3n31t4f5VlD1TQZddH08xbT65ZqA7T4Vkx68emrDZMUOLVvCEAJ6NpAk7DECe3fjC/t52AQ==",
                     "dev": true,
                     "requires": {
-                        "async": "1.5.2",
-                        "babel-plugin-transform-flow-strip-types": "6.22.0",
-                        "babel-preset-es2015": "6.24.1",
-                        "babel-preset-stage-1": "6.24.1",
-                        "babel-register": "6.26.0",
-                        "babylon": "6.18.0",
-                        "colors": "1.3.0",
-                        "flow-parser": "0.73.0",
-                        "lodash": "4.17.10",
-                        "micromatch": "2.3.11",
+                        "async": "^1.5.0",
+                        "babel-plugin-transform-flow-strip-types": "^6.8.0",
+                        "babel-preset-es2015": "^6.9.0",
+                        "babel-preset-stage-1": "^6.5.0",
+                        "babel-register": "^6.9.0",
+                        "babylon": "^6.17.3",
+                        "colors": "^1.1.2",
+                        "flow-parser": "^0.*",
+                        "lodash": "^4.13.1",
+                        "micromatch": "^2.3.7",
                         "node-dir": "0.1.8",
-                        "nomnom": "1.8.1",
-                        "recast": "0.12.9",
-                        "temp": "0.8.3",
-                        "write-file-atomic": "1.3.4"
+                        "nomnom": "^1.8.1",
+                        "recast": "^0.12.5",
+                        "temp": "^0.8.1",
+                        "write-file-atomic": "^1.2.0"
                     }
                 },
                 "recast": {
@@ -21771,10 +22227,10 @@
                     "dev": true,
                     "requires": {
                         "ast-types": "0.10.1",
-                        "core-js": "2.5.7",
-                        "esprima": "4.0.0",
-                        "private": "0.1.8",
-                        "source-map": "0.6.1"
+                        "core-js": "^2.4.1",
+                        "esprima": "~4.0.0",
+                        "private": "~0.1.5",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -21785,17 +22241,17 @@
             "integrity": "sha512-a+UcvlsXvCmclNgfThT8PVyuJKd029By7CxkYEbNNCfs0Lqj9gagjkdv3S3MBvCIKBaUGYs8l4UpiVI0bFoh2Q==",
             "dev": true,
             "requires": {
-                "acorn": "5.6.0",
-                "chalk": "1.1.3",
-                "commander": "2.13.0",
-                "ejs": "2.6.1",
-                "express": "4.16.3",
-                "filesize": "3.6.1",
-                "gzip-size": "3.0.0",
-                "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
-                "opener": "1.4.3",
-                "ws": "3.3.3"
+                "acorn": "^5.1.1",
+                "chalk": "^1.1.3",
+                "commander": "^2.9.0",
+                "ejs": "^2.5.6",
+                "express": "^4.15.2",
+                "filesize": "^3.5.9",
+                "gzip-size": "^3.0.0",
+                "lodash": "^4.17.4",
+                "mkdirp": "^0.5.1",
+                "opener": "^1.4.3",
+                "ws": "^3.3.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -21810,11 +22266,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "gzip-size": {
@@ -21823,7 +22279,7 @@
                     "integrity": "sha1-VGGI6b3DN/Zzdy+BZgRks4nc5SA=",
                     "dev": true,
                     "requires": {
-                        "duplexer": "0.1.1"
+                        "duplexer": "^0.1.1"
                     }
                 },
                 "supports-color": {
@@ -21838,9 +22294,9 @@
                     "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
                     "dev": true,
                     "requires": {
-                        "async-limiter": "1.0.0",
-                        "safe-buffer": "5.1.2",
-                        "ultron": "1.1.1"
+                        "async-limiter": "~1.0.0",
+                        "safe-buffer": "~5.1.0",
+                        "ultron": "~1.1.0"
                     }
                 }
             }
@@ -21851,32 +22307,32 @@
             "integrity": "sha512-gRoWaxSi2JWiYsn1QgOTb6ENwIeSvN1YExZ+kJ0STsTZK7bWPElW+BBBv1UnTbvcPC3v7E17mK8hlFX8DOYSGw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "diff": "3.5.0",
-                "enhanced-resolve": "4.0.0",
-                "envinfo": "4.4.2",
-                "glob-all": "3.1.0",
-                "global-modules": "1.0.0",
-                "got": "8.3.1",
-                "import-local": "1.0.0",
-                "inquirer": "5.2.0",
-                "interpret": "1.1.0",
-                "jscodeshift": "0.5.0",
-                "listr": "0.13.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.10",
-                "log-symbols": "2.2.0",
-                "mkdirp": "0.5.1",
-                "p-each-series": "1.0.0",
-                "p-lazy": "1.0.0",
-                "prettier": "1.11.1",
-                "supports-color": "5.4.0",
-                "v8-compile-cache": "1.1.2",
-                "webpack-addons": "1.1.5",
-                "yargs": "11.1.0",
-                "yeoman-environment": "2.2.0",
-                "yeoman-generator": "2.0.5"
+                "chalk": "^2.3.2",
+                "cross-spawn": "^6.0.5",
+                "diff": "^3.5.0",
+                "enhanced-resolve": "^4.0.0",
+                "envinfo": "^4.4.2",
+                "glob-all": "^3.1.0",
+                "global-modules": "^1.0.0",
+                "got": "^8.2.0",
+                "import-local": "^1.0.0",
+                "inquirer": "^5.1.0",
+                "interpret": "^1.0.4",
+                "jscodeshift": "^0.5.0",
+                "listr": "^0.13.0",
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.5",
+                "log-symbols": "^2.2.0",
+                "mkdirp": "^0.5.1",
+                "p-each-series": "^1.0.0",
+                "p-lazy": "^1.0.0",
+                "prettier": "^1.5.3",
+                "supports-color": "^5.3.0",
+                "v8-compile-cache": "^1.1.2",
+                "webpack-addons": "^1.1.5",
+                "yargs": "^11.1.0",
+                "yeoman-environment": "^2.0.0",
+                "yeoman-generator": "^2.0.3"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -21903,7 +22359,7 @@
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "2.0.0"
+                        "restore-cursor": "^2.0.0"
                     }
                 },
                 "cliui": {
@@ -21912,9 +22368,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "cross-spawn": {
@@ -21923,11 +22379,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "diff": {
@@ -21942,9 +22398,9 @@
                     "integrity": "sha512-jox/62b2GofV1qTUQTMPEJSDIGycS43evqYzD/KVtEb9OCoki9cnacUPxCrZa7JfPzZSYOCZhu9O9luaMxAX8g==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "memory-fs": "0.4.1",
-                        "tapable": "1.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "tapable": "^1.0.0"
                     }
                 },
                 "execa": {
@@ -21953,13 +22409,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -21968,9 +22424,9 @@
                             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                             "dev": true,
                             "requires": {
-                                "lru-cache": "4.1.3",
-                                "shebang-command": "1.2.0",
-                                "which": "1.3.1"
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
                             }
                         }
                     }
@@ -21981,7 +22437,7 @@
                     "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
                     "dev": true,
                     "requires": {
-                        "homedir-polyfill": "1.0.1"
+                        "homedir-polyfill": "^1.0.1"
                     }
                 },
                 "external-editor": {
@@ -21990,9 +22446,9 @@
                     "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
                     "dev": true,
                     "requires": {
-                        "chardet": "0.4.2",
-                        "iconv-lite": "0.4.23",
-                        "tmp": "0.0.33"
+                        "chardet": "^0.4.0",
+                        "iconv-lite": "^0.4.17",
+                        "tmp": "^0.0.33"
                     }
                 },
                 "figures": {
@@ -22001,7 +22457,7 @@
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
                     "dev": true,
                     "requires": {
-                        "escape-string-regexp": "1.0.5"
+                        "escape-string-regexp": "^1.0.5"
                     }
                 },
                 "global-modules": {
@@ -22010,9 +22466,9 @@
                     "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
                     "dev": true,
                     "requires": {
-                        "global-prefix": "1.0.2",
-                        "is-windows": "1.0.2",
-                        "resolve-dir": "1.0.1"
+                        "global-prefix": "^1.0.1",
+                        "is-windows": "^1.0.1",
+                        "resolve-dir": "^1.0.0"
                     }
                 },
                 "global-prefix": {
@@ -22021,11 +22477,11 @@
                     "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
                     "dev": true,
                     "requires": {
-                        "expand-tilde": "2.0.2",
-                        "homedir-polyfill": "1.0.1",
-                        "ini": "1.3.5",
-                        "is-windows": "1.0.2",
-                        "which": "1.3.1"
+                        "expand-tilde": "^2.0.2",
+                        "homedir-polyfill": "^1.0.1",
+                        "ini": "^1.3.4",
+                        "is-windows": "^1.0.1",
+                        "which": "^1.2.14"
                     }
                 },
                 "inquirer": {
@@ -22034,19 +22490,19 @@
                     "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.1",
-                        "cli-cursor": "2.1.0",
-                        "cli-width": "2.2.0",
-                        "external-editor": "2.2.0",
-                        "figures": "2.0.0",
-                        "lodash": "4.17.10",
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.0",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^2.1.0",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.3.0",
                         "mute-stream": "0.0.7",
-                        "run-async": "2.3.0",
-                        "rxjs": "5.5.11",
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "through": "2.3.8"
+                        "run-async": "^2.2.0",
+                        "rxjs": "^5.5.2",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "through": "^2.3.6"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -22067,8 +22523,8 @@
                     "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
                     "dev": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "readable-stream": "2.0.6"
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "mute-stream": {
@@ -22083,7 +22539,7 @@
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "os-locale": {
@@ -22092,9 +22548,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "resolve-dir": {
@@ -22103,8 +22559,8 @@
                     "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
                     "dev": true,
                     "requires": {
-                        "expand-tilde": "2.0.2",
-                        "global-modules": "1.0.0"
+                        "expand-tilde": "^2.0.0",
+                        "global-modules": "^1.0.0"
                     }
                 },
                 "restore-cursor": {
@@ -22113,8 +22569,8 @@
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
                     "dev": true,
                     "requires": {
-                        "onetime": "2.0.1",
-                        "signal-exit": "3.0.2"
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "string-width": {
@@ -22123,8 +22579,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -22133,7 +22589,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "tapable": {
@@ -22148,7 +22604,7 @@
                     "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.2"
                     }
                 },
                 "which-module": {
@@ -22169,18 +22625,18 @@
                     "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     }
                 },
                 "yargs-parser": {
@@ -22189,7 +22645,7 @@
                     "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -22200,13 +22656,13 @@
             "integrity": "sha512-Z11Zp3GTvCe6mGbbtma+lMB9xRfJcNtupXfmvFBujyXqLNms6onDnSi9f/Cb2rw6KkD5kgibOfxhN7npZwTiGA==",
             "dev": true,
             "requires": {
-                "loud-rejection": "1.6.0",
-                "memory-fs": "0.4.1",
-                "mime": "2.3.1",
-                "path-is-absolute": "1.0.1",
-                "range-parser": "1.2.0",
-                "url-join": "4.0.0",
-                "webpack-log": "1.2.0"
+                "loud-rejection": "^1.6.0",
+                "memory-fs": "~0.4.1",
+                "mime": "^2.1.0",
+                "path-is-absolute": "^1.0.0",
+                "range-parser": "^1.0.3",
+                "url-join": "^4.0.0",
+                "webpack-log": "^1.0.1"
             },
             "dependencies": {
                 "memory-fs": {
@@ -22215,8 +22671,8 @@
                     "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
                     "dev": true,
                     "requires": {
-                        "errno": "0.1.7",
-                        "readable-stream": "2.0.6"
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
                     }
                 },
                 "mime": {
@@ -22240,32 +22696,32 @@
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "array-includes": "3.0.3",
-                "bonjour": "3.5.0",
-                "chokidar": "2.0.3",
-                "compression": "1.7.2",
-                "connect-history-api-fallback": "1.5.0",
-                "debug": "3.1.0",
-                "del": "3.0.0",
-                "express": "4.16.3",
-                "html-entities": "1.2.1",
-                "http-proxy-middleware": "0.18.0",
-                "import-local": "1.0.0",
+                "array-includes": "^3.0.3",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.0.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "debug": "^3.1.0",
+                "del": "^3.0.0",
+                "express": "^4.16.2",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.18.0",
+                "import-local": "^1.0.0",
                 "internal-ip": "1.2.0",
-                "ip": "1.1.5",
-                "killable": "1.0.0",
-                "loglevel": "1.6.1",
-                "opn": "5.3.0",
-                "portfinder": "1.0.13",
-                "selfsigned": "1.10.3",
-                "serve-index": "1.9.1",
+                "ip": "^1.1.5",
+                "killable": "^1.0.0",
+                "loglevel": "^1.4.1",
+                "opn": "^5.1.0",
+                "portfinder": "^1.0.9",
+                "selfsigned": "^1.9.1",
+                "serve-index": "^1.7.2",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.1.4",
-                "spdy": "3.4.7",
-                "strip-ansi": "3.0.1",
-                "supports-color": "5.4.0",
+                "spdy": "^3.4.1",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^5.1.0",
                 "webpack-dev-middleware": "3.1.2",
-                "webpack-log": "1.2.0",
+                "webpack-log": "^1.1.2",
                 "yargs": "11.0.0"
             },
             "dependencies": {
@@ -22287,9 +22743,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     },
                     "dependencies": {
                         "strip-ansi": {
@@ -22298,7 +22754,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -22309,12 +22765,12 @@
                     "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
                     "dev": true,
                     "requires": {
-                        "globby": "6.1.0",
-                        "is-path-cwd": "1.0.0",
-                        "is-path-in-cwd": "1.0.1",
-                        "p-map": "1.2.0",
-                        "pify": "3.0.0",
-                        "rimraf": "2.6.2"
+                        "globby": "^6.1.0",
+                        "is-path-cwd": "^1.0.0",
+                        "is-path-in-cwd": "^1.0.0",
+                        "p-map": "^1.1.1",
+                        "pify": "^3.0.0",
+                        "rimraf": "^2.2.8"
                     }
                 },
                 "execa": {
@@ -22323,13 +22779,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "globby": {
@@ -22338,11 +22794,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
@@ -22365,9 +22821,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "string-width": {
@@ -22376,8 +22832,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "strip-ansi": {
@@ -22386,7 +22842,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -22409,18 +22865,18 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.2",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     }
                 },
                 "yargs-parser": {
@@ -22429,7 +22885,7 @@
                     "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -22440,10 +22896,10 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "log-symbols": "2.2.0",
-                "loglevelnext": "1.0.5",
-                "uuid": "3.2.1"
+                "chalk": "^2.1.0",
+                "log-symbols": "^2.1.0",
+                "loglevelnext": "^1.0.1",
+                "uuid": "^3.1.0"
             }
         },
         "webpack-sources": {
@@ -22452,8 +22908,8 @@
             "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "dev": true,
             "requires": {
-                "source-list-map": "2.0.0",
-                "source-map": "0.6.1"
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
             }
         },
         "websocket-driver": {
@@ -22462,8 +22918,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.13",
-                "websocket-extensions": "0.1.3"
+                "http-parser-js": ">=0.4.0",
+                "websocket-extensions": ">=0.1.1"
             }
         },
         "websocket-extensions": {
@@ -22507,7 +22963,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -22540,12 +22996,12 @@
             "integrity": "sha512-QuFHYsRFR/ZhWRxU/VMAXUSfCIgol1iRgJ22mV1bM9GGRycW/VqbyhIcY95GjX0V8rNu+8d65t48xjnrtf9hqw==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "fs-extra": "3.0.1",
-                "glob": "7.1.2",
-                "lodash.template": "4.4.0",
-                "mkdirp": "0.5.1",
-                "workbox-sw": "2.1.3"
+                "chalk": "^1.1.3",
+                "fs-extra": "^3.0.1",
+                "glob": "^7.1.1",
+                "lodash.template": "^4.4.0",
+                "mkdirp": "^0.5.1",
+                "workbox-sw": "^2.1.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -22560,11 +23016,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -22587,7 +23043,7 @@
             "integrity": "sha512-keKOw8pw5UPuau+YBmAhnLF4/IKz8F45eXC6M0BampTJdQk32UACXMLMbTMlUZGWzx+G1iCd52Zac3Tyh4X8dg==",
             "dev": true,
             "requires": {
-                "workbox-build": "2.1.3"
+                "workbox-build": "^2.1.3"
             }
         },
         "worker-farm": {
@@ -22596,7 +23052,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "0.1.7"
+                "errno": "~0.1.7"
             }
         },
         "worker-loader": {
@@ -22605,8 +23061,8 @@
             "integrity": "sha512-qJZLVS/jMCBITDzPo/RuweYSIG8VJP5P67mP/71alGyTZRe1LYJFdwLjLalY3T5ifx0bMDRD3OB6P2p1escvlg==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.4.5"
+                "loader-utils": "^1.0.0",
+                "schema-utils": "^0.4.0"
             }
         },
         "wrap-ansi": {
@@ -22615,8 +23071,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -22630,7 +23086,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "write-file-atomic": {
@@ -22639,9 +23095,9 @@
             "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "slide": "1.1.6"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "slide": "^1.1.5"
             }
         },
         "ws": {
@@ -22650,8 +23106,8 @@
             "integrity": "sha512-ZGh/8kF9rrRNffkLFV4AzhvooEclrOH0xaugmqGsIfFgOE/pIz4fMc4Ef+5HSQqTEug2S9JZIWDR47duDSLfaA==",
             "dev": true,
             "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.2"
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0"
             }
         },
         "xtend": {
@@ -22678,20 +23134,20 @@
             "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
             "dev": true,
             "requires": {
-                "cliui": "3.2.0",
-                "decamelize": "1.2.0",
-                "get-caller-file": "1.0.2",
-                "lodash.assign": "4.2.0",
-                "os-locale": "1.4.0",
-                "read-pkg-up": "1.0.1",
-                "require-directory": "2.1.1",
-                "require-main-filename": "1.0.1",
-                "set-blocking": "2.0.0",
-                "string-width": "1.0.2",
-                "which-module": "1.0.0",
-                "window-size": "0.2.0",
-                "y18n": "3.2.1",
-                "yargs-parser": "2.4.1"
+                "cliui": "^3.2.0",
+                "decamelize": "^1.1.1",
+                "get-caller-file": "^1.0.1",
+                "lodash.assign": "^4.0.3",
+                "os-locale": "^1.4.0",
+                "read-pkg-up": "^1.0.1",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^1.0.1",
+                "which-module": "^1.0.0",
+                "window-size": "^0.2.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^2.4.1"
             },
             "dependencies": {
                 "find-up": {
@@ -22700,8 +23156,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -22710,11 +23166,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "path-exists": {
@@ -22723,7 +23179,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -22732,9 +23188,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -22749,9 +23205,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -22760,8 +23216,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "strip-bom": {
@@ -22770,7 +23226,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "y18n": {
@@ -22787,8 +23243,8 @@
             "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
             "dev": true,
             "requires": {
-                "camelcase": "3.0.0",
-                "lodash.assign": "4.2.0"
+                "camelcase": "^3.0.0",
+                "lodash.assign": "^4.0.6"
             }
         },
         "yeoman-environment": {
@@ -22797,21 +23253,21 @@
             "integrity": "sha512-gQ+hIW8QRlUo4jGBDCm++qg01SXaIVJ7VyLrtSwk2jQG4vtvluWpsGIl7V8DqT2jGiqukdec0uEyffVEyQgaZA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "debug": "3.1.0",
-                "diff": "3.3.1",
-                "escape-string-regexp": "1.0.5",
-                "globby": "8.0.1",
-                "grouped-queue": "0.3.3",
-                "inquirer": "5.2.0",
-                "is-scoped": "1.0.0",
-                "lodash": "4.17.10",
-                "log-symbols": "2.2.0",
-                "mem-fs": "1.1.3",
-                "strip-ansi": "4.0.0",
-                "text-table": "0.2.0",
-                "untildify": "3.0.3"
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^3.1.0",
+                "diff": "^3.3.1",
+                "escape-string-regexp": "^1.0.2",
+                "globby": "^8.0.1",
+                "grouped-queue": "^0.3.3",
+                "inquirer": "^5.2.0",
+                "is-scoped": "^1.0.0",
+                "lodash": "^4.17.10",
+                "log-symbols": "^2.1.0",
+                "mem-fs": "^1.1.0",
+                "strip-ansi": "^4.0.0",
+                "text-table": "^0.2.0",
+                "untildify": "^3.0.2"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -22832,7 +23288,7 @@
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "2.0.0"
+                        "restore-cursor": "^2.0.0"
                     }
                 },
                 "cross-spawn": {
@@ -22841,11 +23297,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "external-editor": {
@@ -22854,9 +23310,9 @@
                     "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
                     "dev": true,
                     "requires": {
-                        "chardet": "0.4.2",
-                        "iconv-lite": "0.4.23",
-                        "tmp": "0.0.33"
+                        "chardet": "^0.4.0",
+                        "iconv-lite": "^0.4.17",
+                        "tmp": "^0.0.33"
                     }
                 },
                 "figures": {
@@ -22865,7 +23321,7 @@
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
                     "dev": true,
                     "requires": {
-                        "escape-string-regexp": "1.0.5"
+                        "escape-string-regexp": "^1.0.5"
                     }
                 },
                 "globby": {
@@ -22874,13 +23330,13 @@
                     "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "dir-glob": "2.0.0",
-                        "fast-glob": "2.2.2",
-                        "glob": "7.1.2",
-                        "ignore": "3.3.8",
-                        "pify": "3.0.0",
-                        "slash": "1.0.0"
+                        "array-union": "^1.0.1",
+                        "dir-glob": "^2.0.0",
+                        "fast-glob": "^2.0.2",
+                        "glob": "^7.1.2",
+                        "ignore": "^3.3.5",
+                        "pify": "^3.0.0",
+                        "slash": "^1.0.0"
                     }
                 },
                 "inquirer": {
@@ -22889,19 +23345,19 @@
                     "integrity": "sha512-E9BmnJbAKLPGonz0HeWHtbKf+EeSP93paWO3ZYoUpq/aowXvYGjjCSuashhXPpzbArIjBbji39THkxTz9ZeEUQ==",
                     "dev": true,
                     "requires": {
-                        "ansi-escapes": "3.1.0",
-                        "chalk": "2.4.1",
-                        "cli-cursor": "2.1.0",
-                        "cli-width": "2.2.0",
-                        "external-editor": "2.2.0",
-                        "figures": "2.0.0",
-                        "lodash": "4.17.10",
+                        "ansi-escapes": "^3.0.0",
+                        "chalk": "^2.0.0",
+                        "cli-cursor": "^2.1.0",
+                        "cli-width": "^2.0.0",
+                        "external-editor": "^2.1.0",
+                        "figures": "^2.0.0",
+                        "lodash": "^4.3.0",
                         "mute-stream": "0.0.7",
-                        "run-async": "2.3.0",
-                        "rxjs": "5.5.11",
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "through": "2.3.8"
+                        "run-async": "^2.2.0",
+                        "rxjs": "^5.5.2",
+                        "string-width": "^2.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "through": "^2.3.6"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -22922,7 +23378,7 @@
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "restore-cursor": {
@@ -22931,8 +23387,8 @@
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
                     "dev": true,
                     "requires": {
-                        "onetime": "2.0.1",
-                        "signal-exit": "3.0.2"
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "string-width": {
@@ -22941,8 +23397,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -22951,7 +23407,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "tmp": {
@@ -22960,7 +23416,7 @@
                     "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
                     "dev": true,
                     "requires": {
-                        "os-tmpdir": "1.0.2"
+                        "os-tmpdir": "~1.0.2"
                     }
                 }
             }
@@ -22971,31 +23427,31 @@
             "integrity": "sha512-rV6tJ8oYzm4mmdF2T3wjY+Q42jKF2YiiD0VKfJ8/0ZYwmhCKC9Xs2346HVLPj/xE13i68psnFJv7iS6gWRkeAg==",
             "dev": true,
             "requires": {
-                "async": "2.6.1",
-                "chalk": "2.4.1",
-                "cli-table": "0.3.1",
-                "cross-spawn": "6.0.5",
-                "dargs": "5.1.0",
-                "dateformat": "3.0.3",
-                "debug": "3.1.0",
-                "detect-conflict": "1.0.1",
-                "error": "7.0.2",
-                "find-up": "2.1.0",
-                "github-username": "4.1.0",
-                "istextorbinary": "2.2.1",
-                "lodash": "4.17.10",
-                "make-dir": "1.3.0",
-                "mem-fs-editor": "4.0.2",
-                "minimist": "1.2.0",
-                "pretty-bytes": "4.0.2",
-                "read-chunk": "2.1.0",
-                "read-pkg-up": "3.0.0",
-                "rimraf": "2.6.2",
-                "run-async": "2.3.0",
-                "shelljs": "0.8.2",
-                "text-table": "0.2.0",
-                "through2": "2.0.3",
-                "yeoman-environment": "2.2.0"
+                "async": "^2.6.0",
+                "chalk": "^2.3.0",
+                "cli-table": "^0.3.1",
+                "cross-spawn": "^6.0.5",
+                "dargs": "^5.1.0",
+                "dateformat": "^3.0.3",
+                "debug": "^3.1.0",
+                "detect-conflict": "^1.0.0",
+                "error": "^7.0.2",
+                "find-up": "^2.1.0",
+                "github-username": "^4.0.0",
+                "istextorbinary": "^2.2.1",
+                "lodash": "^4.17.10",
+                "make-dir": "^1.1.0",
+                "mem-fs-editor": "^4.0.0",
+                "minimist": "^1.2.0",
+                "pretty-bytes": "^4.0.2",
+                "read-chunk": "^2.1.0",
+                "read-pkg-up": "^3.0.0",
+                "rimraf": "^2.6.2",
+                "run-async": "^2.0.0",
+                "shelljs": "^0.8.0",
+                "text-table": "^0.2.0",
+                "through2": "^2.0.0",
+                "yeoman-environment": "^2.0.5"
             },
             "dependencies": {
                 "async": {
@@ -23004,7 +23460,7 @@
                     "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.17.10"
                     }
                 },
                 "cross-spawn": {
@@ -23013,11 +23469,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "load-json-file": {
@@ -23026,10 +23482,10 @@
                     "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "4.0.0",
-                        "pify": "3.0.0",
-                        "strip-bom": "3.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^4.0.0",
+                        "pify": "^3.0.0",
+                        "strip-bom": "^3.0.0"
                     }
                 },
                 "minimist": {
@@ -23044,8 +23500,8 @@
                     "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.1",
-                        "json-parse-better-errors": "1.0.2"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
                 },
                 "read-pkg": {
@@ -23054,9 +23510,9 @@
                     "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "4.0.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "3.0.0"
+                        "load-json-file": "^4.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^3.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -23065,8 +23521,8 @@
                     "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                     "dev": true,
                     "requires": {
-                        "find-up": "2.1.0",
-                        "read-pkg": "3.0.0"
+                        "find-up": "^2.0.0",
+                        "read-pkg": "^3.0.0"
                     }
                 },
                 "shelljs": {
@@ -23075,9 +23531,9 @@
                     "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "interpret": "1.1.0",
-                        "rechoir": "0.6.2"
+                        "glob": "^7.0.0",
+                        "interpret": "^1.0.0",
+                        "rechoir": "^0.6.2"
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@fortawesome/fontawesome-free-webfonts": "^1.0.4",
         "copy-webpack-plugin": "^4.4.1",
         "http-server": "0.10.0",
-        "itk": "9.0.0",
+        "itk": "9.1.1",
         "kw-doc": "1.1.1",
         "kw-web-suite": "6.0.2",
         "lodash": "^4.17.4",


### PR DESCRIPTION
Update itk.js to 9.1.1, which contains a fix for reading many file formats.

@aylward @jourdain @floryst @agirault annoying ImageIO bug has been addressed! :fireworks: Now we can load all that MetaImage goodness :-).

Testing locally.